### PR TITLE
Signed urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,69 @@ var schedulerEvents = new taskcluster.SchedulerEvents(options);
 
 <!-- END OF GENERATED DOCS -->
 
+## Construct Urls
+You can build a url for any request, but this feature is mostly useful for
+request that doesn't require any authentication. If you need authentication
+take a look at the section on building signed urls, which is possible for all
+`GET` requests. To construct a url for a request use the `buildUrl` method, as
+illustrated in the following example:
+
+```js
+// Create queue instance
+var queue = new taskcluster.Queue(...);
+
+// Build url to get a specific task
+var url = queue.buildUrl(
+  queue.getTask,    // Method to build url for.
+  taskId            // First parameter for the method, in this case taskId
+);
+```
+
+Please, note that the `payload` parameter cannot be encoded in urls. And must be
+sent when using a constructed urls. Again, this is not a problem as most methods
+that takes a `payload` also requires authentication.
+
+
+## Construct Signed Urls
+It's possible to build both signed urls for all `GET` requests. A signed url
+contains a query-string parameter called `bewit`, this parameter holds
+expiration time, signature and scope restrictions (if applied). The signature
+covers the following parameters:
+
+  * Expiration time,
+  * Url and query-string, and
+  * scope restrictions (if applied)
+
+These signed urls is very convenient if you want to grant somebody access to
+specific resource without proxying the request or sharing your credentials.
+For example it's fairly safe to provide someone with a signed url for a
+specific artifact that is protected by a scope. See example below.
+
+```js
+// Create queue instance
+var queue = new taskcluster.Queue(...);
+
+// Build signed url
+var signedUrl = queue.buildSignedUrl(
+  queue.getArtifactFromRun,   // method to build signed url for.
+  taskId,                     // TaskId parameter
+  runId,                      // RunId parameter
+  artifactName,               // Artifact name parameter
+  {
+    expiration:     60 * 10   // Expiration time in seconds
+});
+```
+
+Please, note that the `payload` parameter cannot be encoded in the signed url
+and must be sent as request payload. This should work fine, just remember that
+it's only possible to make signed urls for `GET` requests, which in most cases
+don't take a payload.
+
+Also please consider using a relatively limited expiration time, as it's not
+possible to retract a signed url without revoking your credentials.
+For more technical details on signed urls, see _bewit_ urls in
+[hawk](https://github.com/hueniverse/hawk).
+
 ## Create Client Class Dynamically
 You can create a Client class from a reference JSON object as illustrated
 below:

--- a/client.js
+++ b/client.js
@@ -9,7 +9,8 @@ var request     = require('superagent-promise');
 var debug       = require('debug')('taskcluster-client');
 var _           = require('lodash');
 var assert      = require('assert');
-var Hawk        = require('hawk');
+var hawk        = require('hawk');
+var url         = require('url');
 
 // Default options stored globally for convenience
 var _defaultOptions = {
@@ -66,62 +67,6 @@ exports.createClient = function(reference) {
     if (entry.input) {
       nb_args += 1;
     }
-
-    // Utility function to build the request URL, given input parameters
-    var buildUrl = function() {
-      debug("build url for: " + entry.name);
-      // Convert arguments to actual array
-      var args = Array.prototype.slice.call(arguments);
-      // Validate number of arguments
-      var nb_url_params = nb_args - 1;
-      if (args.length != nb_url_params) {
-        throw new Error("Function " + entry.name + "buildUrl() takes " +
-                        nb_url_params + "arguments, but was given " + args.length +
-                        " arguments");
-      }
-      // Substitute parameters into route
-      var endpoint = entry.route;
-      entry.args.forEach(function(arg) {
-        var value = args.shift();
-        // Replace with empty string in case of undefined or null argument
-        if (value === undefined || value === null) {
-          value = '';
-        }
-        endpoint = endpoint.replace('<' + arg + '>', value);
-      });
-
-      return this._options.baseUrl + endpoint;
-    };
-
-    // Utility function to construct a bewit URL for GET requests
-    var signedUrl = function() {
-      // Convert arguments to actual array
-      var args = Array.prototype.slice.call(arguments);
-      if (args.length != nb_args) {
-        throw new Error("Function " + entry.name + ".signedUrl() takes " +
-                        nb_args + "arguments, but was given " + args.length +
-                        " arguments");
-      }
-      // Get expiration
-      var expiration = args.pop();
-      assert(typeof(expiration) === 'number', "expiration must be a number");
-      // Build the URL
-
-      // SHIT we can't get this in the current context... find another way!!
-      assert(this._options.credentials.clientId, "credentials must be given");
-      assert(this._options.credentials.accessToken,
-             "accessToken must be given");
-      var url = buildUrl.call(undefined, args);
-      var bewit = Hawk.uri.getBewit(url, {
-        credentials:    {
-          id:         this._options.credentials.clientId,
-          key:        this._options.credentials.accessToken,
-          algorithm:  'sha256'
-        },
-        ttlSec:         expiration,
-        ext:            'some-app-data'
-      });
-    };
 
     // Create method on prototype
     Client.prototype[entry.name] = function() {
@@ -187,6 +132,8 @@ exports.createClient = function(reference) {
         return res.body;
       });
     };
+    // Add reference for buildUrl and signUrl
+    Client.prototype[entry.name].entryReference = entry;
   });
 
   // For each topic-exchange entry
@@ -232,6 +179,121 @@ exports.createClient = function(reference) {
       };
     };
   });
+
+  // Utility function to build the request URL for given method and
+  // input parameters
+  Client.prototype.buildUrl = function() {
+      // Convert arguments to actual array
+      var args = Array.prototype.slice.call(arguments);
+      if (args.length == 0) {
+        throw new Error("buildUrl(method, arg1, arg2, ...) takes a least one " +
+                        "argument!");
+      }
+      // Find the method
+      var method = args.shift();
+      var entry  = method.entryReference;
+      if (!entry || entry.type !== 'function') {
+        throw new Error("method in buildUrl(method, arg1, arg2, ...) must be " +
+                        "an API method from the same object!");
+      }
+
+      debug("build url for: " + entry.name);
+      // Validate number of arguments
+      if (args.length != entry.args.length) {
+        throw new Error("Function " + entry.name + "buildUrl() takes " +
+                        (entry.args.length + 1) + " arguments, but was given " +
+                        (args.length + 1) + " arguments");
+      }
+      // Substitute parameters into route
+      var endpoint = entry.route;
+      entry.args.forEach(function(arg) {
+        var value = args.shift();
+        // Replace with empty string in case of undefined or null argument
+        if (value === undefined || value === null) {
+          value = '';
+        }
+        endpoint = endpoint.replace('<' + arg + '>', value);
+      });
+
+      return this._options.baseUrl + endpoint;
+    };
+
+    // Utility function to construct a bewit URL for GET requests
+    Client.prototype.buildSignedUrl = function() {
+      // Convert arguments to actual array
+      var args = Array.prototype.slice.call(arguments);
+      if (args.length == 0) {
+        throw new Error("buildSignedUrl(method, arg1, arg2, ..., [options]) " +
+                        "takes a least one argument!");
+      }
+
+      // Find method and reference entry
+      var method = args[0];
+      var entry  = method.entryReference;
+      if (entry.method !== 'get') {
+        throw new Error("buildSignedUrl only works for GET requests");
+      }
+
+      // Default to 15 minutes before expiration
+      var expiration = 15 * 60;
+
+      // if longer than method + args, then we have options too
+      if (args.length > entry.args.length + 1) {
+        // Get request options
+        var options = args.pop();
+
+        // Get expiration from options
+        expiration = options.expiration || expiration;
+
+        // Complain if expiration isn't a number
+        if (typeof(expiration) !== 'number') {
+          throw new Error("options.expiration must be a number");
+        }
+      }
+
+      // Build URL
+      var requestUrl = this.buildUrl.apply(this, args);
+
+      // Check that we have credentials
+      if (!this._options.credentials.clientId) {
+        throw new Error("credentials must be given");
+      }
+      if (!this._options.credentials.accessToken) {
+        throw new Error("accessToken must be given");
+      }
+
+      // Generate meta-data to include
+      var ext = undefined;
+      // If set of authorized scopes is provided, we'll restrict the request
+      // to only use these scopes
+      if (this._options.authorizedScopes instanceof Array) {
+        ext = new Buffer(JSON.stringify({
+          authorizedScopes: this._options.authorizedScopes
+        })).toString('base64');
+      }
+
+      // Create bewit
+      var bewit = hawk.uri.getBewit(requestUrl, {
+        credentials:    {
+          id:         this._options.credentials.clientId,
+          key:        this._options.credentials.accessToken,
+          algorithm:  'sha256'
+        },
+        ttlSec:         expiration,
+        ext:            ext
+      });
+
+      // Add bewit to requestUrl
+      var urlParts = url.parse(requestUrl);
+      if (urlParts.search) {
+        urlParts.search += "&bewit=" + bewit;
+      } else {
+        urlParts.search = "?bewit=" + bewit;
+      }
+
+      // Return formatted URL
+      return url.format(urlParts);
+    };
 
   // Return client class
   return Client;

--- a/package.json
+++ b/package.json
@@ -20,13 +20,14 @@
     "superagent-hawk":                  "0.0.3",
     "amqplib":                          "0.2.0",
     "slugid":                           "1.0.1",
-    "promise":                          "5.0.0"
+    "promise":                          "5.0.0",
+    "hawk":                             "2.2.3"
   },
   "devDependencies": {
     "mocha":                            "1.18.2",
     "commander":                        "2.2.0",
     "cliff":                            "0.1.8",
-    "taskcluster-base":                 "0.3.2",
+    "taskcluster-base":                 "0.3.8",
     "browserify":                       "5.9.1",
     "mocha-phantomjs":                  "3.5.0"
   }


### PR DESCRIPTION
Methods:
- `buildUrl(method, arg1, arg2, ...)`, and
- `buildSignedUrl(method, arg1, arg2, ..., {expiration: 60 * 5})`

The method `buildSignedUrl` only works with `GET` requests... but all in all this pretty nice...
Give it a quick review and let me know if you have concerns.

To support signed URLs we need to upgrade to newest version of `taskcluster-base`, I've already started this for `taskcluster-queue`, basically I want signed urls for getting artifacts :)
They work like a charm for this as they redirect with another signaure (S3 or SAS) to the actual artifact... It's beautiful :)
