### PR TITLE
Assign defaults to a new object so we don't mutate given options

### DIFF
--- a/client.js
+++ b/client.js
@@ -52,7 +52,7 @@ var _defaultOptions = {
 exports.createClient = function(reference) {
   // Client class constructor
   var Client = function(options) {
-    this._options = _.defaults(options || {}, {
+    this._options = _.defaults({}, options || {}, {
       baseUrl:          reference.baseUrl        || '',
       exchangePrefix:   reference.exchangePrefix || ''
     }, _defaultOptions);
@@ -326,5 +326,5 @@ _.forIn(apis, function(api, name) {
  * Example: `Client.config({credentials: {...}});`
  */
 exports.config = function(options) {
-  _defaultOptions = _.defaults(options, _defaultOptions);
+  _defaultOptions = _.defaults({}, options, _defaultOptions);
 };


### PR DESCRIPTION
See this http://lodash.com/docs#defaults

Didn't this before because I was using env variables for authentication (and now I was doing something more explicit) assuming this was unintentional but we should not mutate any objects given to us (the client).
