### PR TITLE
Extended from now

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,6 +6,7 @@ var timeExp = new RegExp([
   '^',
   '(\\s*(\\d+)\\s*y((ears?)|r)?)?',
   '(\\s*(\\d+)\\s*mo(nths?)?)?',
+  '(\\s*(\\d+)\\s*w((eeks?)|k)?)?',
   '(\\s*(\\d+)\\s*d(ays?)?)?',
   '(\\s*(\\d+)\\s*h((ours?)|r)?)?',
   '(\\s*(\\d+)\\s*m(in(utes?)?)?)?',
@@ -25,10 +26,11 @@ var parseTime = function(str) {
   return {
     years:    parseInt(match[2]   || 0),
     months:   parseInt(match[6]   || 0),
-    days:     parseInt(match[9]   || 0),
-    hours:    parseInt(match[12]  || 0),
-    minutes:  parseInt(match[16]  || 0),
-    seconds:  parseInt(match[20]  || 0)
+    weeks:    parseInt(match[9]   || 0),
+    days:     parseInt(match[13]  || 0),
+    hours:    parseInt(match[16]  || 0),
+    minutes:  parseInt(match[20]  || 0),
+    seconds:  parseInt(match[24]  || 0)
   };
 };
 
@@ -46,15 +48,23 @@ var relativeTime = function(offset, reference) {
   if (!offset || typeof(offset) === 'string') {
     offset = parseTime(offset);
   }
-  return new Date(
+  var retval = new Date(
     reference.getTime()
-    + offset.years   * 365 * 24 * 60 * 60 * 1000
-    + offset.months  *  31 * 24 * 60 * 60 * 1000
-    + offset.days          * 24 * 60 * 60 * 1000
-    + offset.hours              * 60 * 60 * 1000
-    + offset.minutes                 * 60 * 1000
-    + offset.seconds                      * 1000
+    + offset.weeks   * 7 * 24 * 60 * 60 * 1000
+    + offset.days        * 24 * 60 * 60 * 1000
+    + offset.hours            * 60 * 60 * 1000
+    + offset.minutes               * 60 * 1000
+    + offset.seconds                    * 1000
   );
+  if (offset.months > 0) {
+    var months = offset.months + retval.getMonth()
+    offset.years += Math.floor(months / 12);
+    retval.setMonth(months % 12);
+  }
+  if (offset.years > 0) {
+    retval.setFullYear(retval.getFullYear() + offset.years);
+  }
+  return retval;
 };
 
 // Export relativeTime

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,18 @@
 "use strict";
 
-// Regular expression matching: X days Y hours Z minutes
-var timeExp = /^(\s*(\d+)\s*d(ays?)?)?(\s*(\d+)\s*h(ours?)?)?(\s*(\d+)\s*m(in(utes?)?)?)?\s*$/;
+// Regular expression matching:
+// A years B months C days D hours E minutes F seconds
+var timeExp = new RegExp([
+  '^',
+  '(\\s*(\\d+)\\s*y((ears?)|r)?)?',
+  '(\\s*(\\d+)\\s*mo(nths?)?)?',
+  '(\\s*(\\d+)\\s*d(ays?)?)?',
+  '(\\s*(\\d+)\\s*h((ours?)|r)?)?',
+  '(\\s*(\\d+)\\s*m(in(utes?)?)?)?',
+  '(\\s*(\\d+)\\s*s(ec(onds?)?)?)?',
+  '\\s*$'
+].join(''), 'i');
+
 
 /** Parse time string */
 var parseTime = function(str) {
@@ -12,9 +23,12 @@ var parseTime = function(str) {
   }
   // Return parsed values
   return {
-    days:     parseInt(match[2] || 0),
-    hours:    parseInt(match[5] || 0),
-    minutes:  parseInt(match[8] || 0)
+    years:    parseInt(match[2]   || 0),
+    months:   parseInt(match[6]   || 0),
+    days:     parseInt(match[9]   || 0),
+    hours:    parseInt(match[12]  || 0),
+    minutes:  parseInt(match[16]  || 0),
+    seconds:  parseInt(match[20]  || 0)
   };
 };
 
@@ -34,9 +48,12 @@ var relativeTime = function(offset, reference) {
   }
   return new Date(
     reference.getTime()
-    + offset.days * 24 * 60 * 60 * 1000
-    + offset.hours     * 60 * 60 * 1000
-    + offset.minutes        * 60 * 1000
+    + offset.years   * 365 * 24 * 60 * 60 * 1000
+    + offset.months  *  31 * 24 * 60 * 60 * 1000
+    + offset.days          * 24 * 60 * 60 * 1000
+    + offset.hours              * 60 * 60 * 1000
+    + offset.minutes                 * 60 * 1000
+    + offset.seconds                      * 1000
   );
 };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,7 +3,7 @@
 // Regular expression matching:
 // A years B months C days D hours E minutes F seconds
 var timeExp = new RegExp([
-  '^',
+  '^(\\s*(-|\\+))?',
   '(\\s*(\\d+)\\s*y((ears?)|r)?)?',
   '(\\s*(\\d+)\\s*mo(nths?)?)?',
   '(\\s*(\\d+)\\s*w((eeks?)|k)?)?',
@@ -22,15 +22,17 @@ var parseTime = function(str) {
   if (!match) {
     throw new Error("String: '" + str + "' isn't a time expression");
   }
+  // Negate if needed
+  var neg = (match[2] === '-' ? - 1 : 1);
   // Return parsed values
   return {
-    years:    parseInt(match[2]   || 0),
-    months:   parseInt(match[6]   || 0),
-    weeks:    parseInt(match[9]   || 0),
-    days:     parseInt(match[13]  || 0),
-    hours:    parseInt(match[16]  || 0),
-    minutes:  parseInt(match[20]  || 0),
-    seconds:  parseInt(match[24]  || 0)
+    years:    parseInt(match[4]   || 0) * neg,
+    months:   parseInt(match[8]   || 0) * neg,
+    weeks:    parseInt(match[11]  || 0) * neg,
+    days:     parseInt(match[15]  || 0) * neg,
+    hours:    parseInt(match[18]  || 0) * neg,
+    minutes:  parseInt(match[22]  || 0) * neg,
+    seconds:  parseInt(match[26]  || 0) * neg
   };
 };
 
@@ -56,12 +58,10 @@ var relativeTime = function(offset, reference) {
     + offset.minutes               * 60 * 1000
     + offset.seconds                    * 1000
   );
-  if (offset.months > 0) {
-    var months = offset.months + retval.getMonth()
-    offset.years += Math.floor(months / 12);
-    retval.setMonth(months % 12);
+  if (offset.months !== 0) {
+    retval.setMonth(retval.getMonth() + offset.months);
   }
-  if (offset.years > 0) {
+  if (offset.years !== 0) {
     retval.setFullYear(retval.getFullYear() + offset.years);
   }
   return retval;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name":         "taskcluster-client",
-  "version":      "0.19.5",
+  "version":      "0.19.6",
   "author":       "Jonas Finnemann Jensen <jopsen@gmail.com>",
   "description":  "Client for interfacing taskcluster components",
   "license":      "MPL-2.0",

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -24,6 +24,17 @@ suite('taskcluster.utils', function() {
     assert.equal(taskcluster.utils.parseTime('  1 months   ').months, 1);
   });
 
+  test('parseTime 1 week', function() {
+    assert.equal(taskcluster.utils.parseTime('1w').weeks, 1);
+    assert.equal(taskcluster.utils.parseTime('1 wk').weeks, 1);
+    assert.equal(taskcluster.utils.parseTime('1 week').weeks, 1);
+    assert.equal(taskcluster.utils.parseTime('1 weeks').weeks, 1);
+    assert.equal(taskcluster.utils.parseTime('1week').weeks, 1);
+    assert.equal(taskcluster.utils.parseTime('1    wk').weeks, 1);
+    assert.equal(taskcluster.utils.parseTime('  1    week   ').weeks, 1);
+    assert.equal(taskcluster.utils.parseTime('  1 weeks   ').weeks, 1);
+  });
+
   test('parseTime 1 day', function() {
     assert.equal(taskcluster.utils.parseTime('1d').days, 1);
     assert.equal(taskcluster.utils.parseTime('1 d').days, 1);
@@ -81,13 +92,14 @@ suite('taskcluster.utils', function() {
     assert.equal(taskcluster.utils.parseTime('  45 seconds   ').seconds, 45);
   });
 
-  test('parseTime 1yr2mo3d4h5m6s', function() {
-    assert.equal(taskcluster.utils.parseTime('1yr2mo3d4h5m6s').years, 1);
-    assert.equal(taskcluster.utils.parseTime('1yr2mo3d4h5m6s').months, 2);
-    assert.equal(taskcluster.utils.parseTime('1yr2mo3d4h5m6s').days, 3);
-    assert.equal(taskcluster.utils.parseTime('1yr2mo3d4h5m6s').hours, 4);
-    assert.equal(taskcluster.utils.parseTime('1yr2mo3d4h5m6s').minutes, 5);
-    assert.equal(taskcluster.utils.parseTime('1yr2mo3d4h5m6s').seconds, 6);
+  test('parseTime 1yr2mo3w4d5h6m7s', function() {
+    assert.equal(taskcluster.utils.parseTime('1yr2mo3w4d5h6m7s').years, 1);
+    assert.equal(taskcluster.utils.parseTime('1yr2mo3w4d5h6m7s').months, 2);
+    assert.equal(taskcluster.utils.parseTime('1yr2mo3w4d5h6m7s').weeks, 3);
+    assert.equal(taskcluster.utils.parseTime('1yr2mo3w4d5h6m7s').days, 4);
+    assert.equal(taskcluster.utils.parseTime('1yr2mo3w4d5h6m7s').hours, 5);
+    assert.equal(taskcluster.utils.parseTime('1yr2mo3w4d5h6m7s').minutes, 6);
+    assert.equal(taskcluster.utils.parseTime('1yr2mo3w4d5h6m7s').seconds, 7);
     assert.equal(taskcluster.utils.parseTime('2d3h').minutes, 0);
     assert.equal(taskcluster.utils.parseTime('2d0h').hours, 0);
   });
@@ -119,6 +131,36 @@ suite('taskcluster.utils', function() {
     var d2 = new Date(ts);
 
     // Allow for 10 ms margin
+    assert(Math.abs(d2.getTime() - d1.getTime()) <= 10);
+  });
+
+  test('fromNow(2 years 15)', function() {
+    var d1 = new Date();
+    d1.setMonth(d1.getMonth() + 12 * 2 + 15)
+    var ts = taskcluster.utils.fromNow('2 years 15mo');
+    var d2 = new Date(ts);
+
+    // Allow for 10msy margin
+    assert(Math.abs(d2.getTime() - d1.getTime()) <= 10);
+  });
+
+  test('fromNow(2 years 55)', function() {
+    var d1 = new Date();
+    d1.setMonth(d1.getMonth() + 12 * 2 + 55)
+    var ts = taskcluster.utils.fromNow('2 years 55mo');
+    var d2 = new Date(ts);
+
+    // Allow for 10msy margin
+    assert(Math.abs(d2.getTime() - d1.getTime()) <= 10);
+  });
+
+  test('fromNow(20 years)', function() {
+    var d1 = new Date();
+    d1.setFullYear(d1.getFullYear() + 20)
+    var ts = taskcluster.utils.fromNow('20 years');
+    var d2 = new Date(ts);
+
+    // Allow for 10msy margin
     assert(Math.abs(d2.getTime() - d1.getTime()) <= 10);
   });
 });

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -2,6 +2,28 @@ suite('taskcluster.utils', function() {
   var taskcluster       = require('../');
   var assert            = require('assert');
 
+  test('parseTime 1 year', function() {
+    assert.equal(taskcluster.utils.parseTime('1y').years, 1);
+    assert.equal(taskcluster.utils.parseTime('1 yr').years, 1);
+    assert.equal(taskcluster.utils.parseTime('1 year').years, 1);
+    assert.equal(taskcluster.utils.parseTime('1 years').years, 1);
+    assert.equal(taskcluster.utils.parseTime('1year').years, 1);
+    assert.equal(taskcluster.utils.parseTime('1    yr').years, 1);
+    assert.equal(taskcluster.utils.parseTime('  1    year   ').years, 1);
+    assert.equal(taskcluster.utils.parseTime('  1 years   ').years, 1);
+  });
+
+  test('parseTime 1 month', function() {
+    assert.equal(taskcluster.utils.parseTime('1mo').months, 1);
+    assert.equal(taskcluster.utils.parseTime('1 mo').months, 1);
+    assert.equal(taskcluster.utils.parseTime('1 month').months, 1);
+    assert.equal(taskcluster.utils.parseTime('1 months').months, 1);
+    assert.equal(taskcluster.utils.parseTime('1month').months, 1);
+    assert.equal(taskcluster.utils.parseTime('1    mo').months, 1);
+    assert.equal(taskcluster.utils.parseTime('  1    month   ').months, 1);
+    assert.equal(taskcluster.utils.parseTime('  1 months   ').months, 1);
+  });
+
   test('parseTime 1 day', function() {
     assert.equal(taskcluster.utils.parseTime('1d').days, 1);
     assert.equal(taskcluster.utils.parseTime('1 d').days, 1);
@@ -39,6 +61,7 @@ suite('taskcluster.utils', function() {
     assert.equal(taskcluster.utils.parseTime('45m').minutes, 45);
     assert.equal(taskcluster.utils.parseTime('45 m').minutes, 45);
     assert.equal(taskcluster.utils.parseTime('45 min').minutes, 45);
+    assert.equal(taskcluster.utils.parseTime('45 minute').minutes, 45);
     assert.equal(taskcluster.utils.parseTime('45 minutes').minutes, 45);
     assert.equal(taskcluster.utils.parseTime('45minutes').minutes, 45);
     assert.equal(taskcluster.utils.parseTime('45    m').minutes, 45);
@@ -46,10 +69,25 @@ suite('taskcluster.utils', function() {
     assert.equal(taskcluster.utils.parseTime('  45 minutes   ').minutes, 45);
   });
 
-  test('parseTime 2d3h6m', function() {
-    assert.equal(taskcluster.utils.parseTime('2d3h6m').days, 2);
-    assert.equal(taskcluster.utils.parseTime('2d3h6m').hours, 3);
-    assert.equal(taskcluster.utils.parseTime('2d3h6m').minutes, 6);
+  test('parseTime 45 seconds', function() {
+    assert.equal(taskcluster.utils.parseTime('45 s').seconds, 45);
+    assert.equal(taskcluster.utils.parseTime('45 s').seconds, 45);
+    assert.equal(taskcluster.utils.parseTime('45 sec').seconds, 45);
+    assert.equal(taskcluster.utils.parseTime('45 second').seconds, 45);
+    assert.equal(taskcluster.utils.parseTime('45 seconds').seconds, 45);
+    assert.equal(taskcluster.utils.parseTime('45seconds').seconds, 45);
+    assert.equal(taskcluster.utils.parseTime('45    s').seconds, 45);
+    assert.equal(taskcluster.utils.parseTime('  45    sec   ').seconds, 45);
+    assert.equal(taskcluster.utils.parseTime('  45 seconds   ').seconds, 45);
+  });
+
+  test('parseTime 1yr2mo3d4h5m6s', function() {
+    assert.equal(taskcluster.utils.parseTime('1yr2mo3d4h5m6s').years, 1);
+    assert.equal(taskcluster.utils.parseTime('1yr2mo3d4h5m6s').months, 2);
+    assert.equal(taskcluster.utils.parseTime('1yr2mo3d4h5m6s').days, 3);
+    assert.equal(taskcluster.utils.parseTime('1yr2mo3d4h5m6s').hours, 4);
+    assert.equal(taskcluster.utils.parseTime('1yr2mo3d4h5m6s').minutes, 5);
+    assert.equal(taskcluster.utils.parseTime('1yr2mo3d4h5m6s').seconds, 6);
     assert.equal(taskcluster.utils.parseTime('2d3h').minutes, 0);
     assert.equal(taskcluster.utils.parseTime('2d0h').hours, 0);
   });

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -13,6 +13,28 @@ suite('taskcluster.utils', function() {
     assert.equal(taskcluster.utils.parseTime('  1 years   ').years, 1);
   });
 
+  test('parseTime -1 year', function() {
+    assert.equal(taskcluster.utils.parseTime('- 1y').years, -1);
+    assert.equal(taskcluster.utils.parseTime('- 1 yr').years, -1);
+    assert.equal(taskcluster.utils.parseTime('- 1 year').years, -1);
+    assert.equal(taskcluster.utils.parseTime('- 1 years').years, -1);
+    assert.equal(taskcluster.utils.parseTime('- 1year').years, -1);
+    assert.equal(taskcluster.utils.parseTime('- 1    yr').years, -1);
+    assert.equal(taskcluster.utils.parseTime('  - 1    year   ').years, -1);
+    assert.equal(taskcluster.utils.parseTime('  -  1 years   ').years, -1);
+  });
+
+  test('parseTime +1 year', function() {
+    assert.equal(taskcluster.utils.parseTime('+ 1y').years, 1);
+    assert.equal(taskcluster.utils.parseTime('+ 1 yr').years, 1);
+    assert.equal(taskcluster.utils.parseTime('+ 1 year').years, 1);
+    assert.equal(taskcluster.utils.parseTime('+ 1 years').years, 1);
+    assert.equal(taskcluster.utils.parseTime('+ 1year').years, 1);
+    assert.equal(taskcluster.utils.parseTime('+ 1    yr').years, 1);
+    assert.equal(taskcluster.utils.parseTime('  + 1    year   ').years, 1);
+    assert.equal(taskcluster.utils.parseTime('  +  1 years   ').years, 1);
+  });
+
   test('parseTime 1 month', function() {
     assert.equal(taskcluster.utils.parseTime('1mo').months, 1);
     assert.equal(taskcluster.utils.parseTime('1 mo').months, 1);
@@ -22,6 +44,17 @@ suite('taskcluster.utils', function() {
     assert.equal(taskcluster.utils.parseTime('1    mo').months, 1);
     assert.equal(taskcluster.utils.parseTime('  1    month   ').months, 1);
     assert.equal(taskcluster.utils.parseTime('  1 months   ').months, 1);
+  });
+
+  test('parseTime -1 month', function() {
+    assert.equal(taskcluster.utils.parseTime('- 1mo').months, -1);
+    assert.equal(taskcluster.utils.parseTime('- 1 mo').months, -1);
+    assert.equal(taskcluster.utils.parseTime('- 1 month').months, -1);
+    assert.equal(taskcluster.utils.parseTime('- 1 months').months, -1);
+    assert.equal(taskcluster.utils.parseTime('- 1month').months, -1);
+    assert.equal(taskcluster.utils.parseTime('- 1    mo').months, -1);
+    assert.equal(taskcluster.utils.parseTime('  - 1    month   ').months, -1);
+    assert.equal(taskcluster.utils.parseTime('  - 1 months   ').months, -1);
   });
 
   test('parseTime 1 week', function() {
@@ -103,6 +136,17 @@ suite('taskcluster.utils', function() {
     assert.equal(taskcluster.utils.parseTime('2d3h').minutes, 0);
     assert.equal(taskcluster.utils.parseTime('2d0h').hours, 0);
   });
+  test('parseTime -1yr2mo3w4d5h6m7s', function() {
+    assert.equal(taskcluster.utils.parseTime('-1yr2mo3w4d5h6m7s').years, -1);
+    assert.equal(taskcluster.utils.parseTime('-1yr2mo3w4d5h6m7s').months, -2);
+    assert.equal(taskcluster.utils.parseTime('-1yr2mo3w4d5h6m7s').weeks, -3);
+    assert.equal(taskcluster.utils.parseTime('-1yr2mo3w4d5h6m7s').days, -4);
+    assert.equal(taskcluster.utils.parseTime('-1yr2mo3w4d5h6m7s').hours, -5);
+    assert.equal(taskcluster.utils.parseTime('-1yr2mo3w4d5h6m7s').minutes, -6);
+    assert.equal(taskcluster.utils.parseTime('-1yr2mo3w4d5h6m7s').seconds, -7);
+    assert.equal(taskcluster.utils.parseTime('-2d3h').minutes, 0);
+    assert.equal(taskcluster.utils.parseTime('-2d0h').hours, 0);
+  });
 
   test('relativeTime', function() {
     var d1 = new Date();
@@ -134,23 +178,43 @@ suite('taskcluster.utils', function() {
     assert(Math.abs(d2.getTime() - d1.getTime()) <= 10);
   });
 
-  test('fromNow(2 years 15)', function() {
+  test('fromNow(2 years 15 months)', function() {
     var d1 = new Date();
     d1.setMonth(d1.getMonth() + 12 * 2 + 15)
     var ts = taskcluster.utils.fromNow('2 years 15mo');
     var d2 = new Date(ts);
 
-    // Allow for 10msy margin
+    // Allow for 10ms margin
     assert(Math.abs(d2.getTime() - d1.getTime()) <= 10);
   });
 
-  test('fromNow(2 years 55)', function() {
+  test('fromNow(2 years 55 months)', function() {
     var d1 = new Date();
     d1.setMonth(d1.getMonth() + 12 * 2 + 55)
     var ts = taskcluster.utils.fromNow('2 years 55mo');
     var d2 = new Date(ts);
 
-    // Allow for 10msy margin
+    // Allow for 10ms margin
+    assert(Math.abs(d2.getTime() - d1.getTime()) <= 10);
+  });
+
+  test('fromNow(240 months)', function() {
+    var d1 = new Date();
+    d1.setFullYear(d1.getFullYear() + 20)
+    var ts = taskcluster.utils.fromNow('240 months');
+    var d2 = new Date(ts);
+
+    // Allow for 10ms margin
+    assert(Math.abs(d2.getTime() - d1.getTime()) <= 10);
+  });
+
+  test('fromNow(-240 months)', function() {
+    var d1 = new Date();
+    d1.setFullYear(d1.getFullYear() - 20)
+    var ts = taskcluster.utils.fromNow('-240 months');
+    var d2 = new Date(ts);
+
+    // Allow for 10ms margin
     assert(Math.abs(d2.getTime() - d1.getTime()) <= 10);
   });
 
@@ -160,7 +224,7 @@ suite('taskcluster.utils', function() {
     var ts = taskcluster.utils.fromNow('20 years');
     var d2 = new Date(ts);
 
-    // Allow for 10msy margin
+    // Allow for 10ms margin
     assert(Math.abs(d2.getTime() - d1.getTime()) <= 10);
   });
 });


### PR DESCRIPTION
Add support for more years, months, weeks and seconds in `taskcluster.utils.fromNow`.

Note:
I suggest that month can be written as: `mo`, `month` and `months`
And minute can be written as: `m`, `min`, `minute` and `minutes`.

I'm very open to rejecting the `m` form for minutes as it could be confused with month...
On the other hand it would break compatibility, though we don't have many current uses.

Suggestions, it's `3 m` easily read as months instead of minutes... Or is not a problem? 