### PR TITLE
Added docs for fromNow, renamed and removed utils namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,58 @@ var listener = new taskcluster.PulseListener({
 connection.close();                 // Disconnect from AMQP/pulse
 ```
 
+## Relative Date-time Utilities
+A lot of taskcluster APIs requires ISO 8601 time stamps offset into the future
+as way of providing expiration, deadlines, etc. These can be easily created
+using `new Date().toJSON()`, however, it can be rather error prone and tedious
+to offset `Date` objects into the future. Therefore this library comes with two
+utility functions for this purposes.
+
+```js
+var dateObject = taskcluster.fromNow("2 days 3 hours 1 minute");
+var dateString = taskcluster.fromNowJSON("2 days 3 hours 1 minute");
+assert(dateObject.toJSON() === dateString);
+// dateObject = now() + 2 days 2 hours and 1 minute
+assert(new Date().getTime() < dateObject.getTime());
+```
+
+By default it will offset the date time into the future, if the offset strings
+are prefixed minus (`-`) the date object will be offset into the past. This is
+useful in some corner cases.
+
+```js
+var dateObject = taskcluster.fromNow("- 1 year 2 months 3 weeks 5 seconds");
+// dateObject = now() - 1 year, 2 months, 3 weeks and 5 seconds
+assert(new Date().getTime() > dateObject.getTime());
+```
+
+The offset string is ignorant of whitespace and case insensitive. It may also
+optionally be prefixed plus `+` (if not prefixed minus), any `+` prefix will be
+ignored. However, entries in the offset string must be given in order from
+high to low, ie. `2 years 1 day`. Additionally, various shorthands may be
+employed, as illustrated below.
+
+```
+  years,    year,   yr,   y
+  months,   month,  mo
+  weeks,    week,   wk,   w
+  days,     day,          d
+  hours,    hour,   hr,   h
+  minutes,  minute, min
+  seconds,  second, sec,  s
+```
+
+The `fromNow` method may also be given a date to be relative to as a second
+argument. This is useful if offset the task expiration relative to the the task
+deadline or doing something similar.
+
+```js
+var dateObject1 = taskcluster.fromNow("2 days 3 hours");
+// dateObject1  = now() + 2 days and 3 hours
+var dateObject2 = taskcluster.fromNow("1 year", dateObject1);
+// dateObject2  = now() + 1 year, 2 days and 3 hours
+```
+
 ## Using `taskcluster-client` in a Browser
 Running the script `utils/browserify.js` will generate `taskcluster-client.js`
 using browserify. This does not contain any listener, but all the API logic

--- a/index.js
+++ b/index.js
@@ -9,11 +9,9 @@ _.defaults(exports,
   require('./lib/client'),
   require('./lib/amqplistener'),
   require('./lib/pulselistener'),
-  require('./lib/weblistener')
+  require('./lib/weblistener'),
+  require('./lib/utils')
 );
-
-// Export utils as taskcluster.utils...
-exports.utils = require('./lib/utils');
 
 // Provide a SockJS client implementation for the WebListener
 Object.defineProperty(exports.WebListener, 'SockJS', {

--- a/lib/parsetime.js
+++ b/lib/parsetime.js
@@ -1,0 +1,40 @@
+"use strict";
+
+// Regular expression matching:
+// A years B months C days D hours E minutes F seconds
+var timeExp = new RegExp([
+  '^(\\s*(-|\\+))?',
+  '(\\s*(\\d+)\\s*y((ears?)|r)?)?',
+  '(\\s*(\\d+)\\s*mo(nths?)?)?',
+  '(\\s*(\\d+)\\s*w((eeks?)|k)?)?',
+  '(\\s*(\\d+)\\s*d(ays?)?)?',
+  '(\\s*(\\d+)\\s*h((ours?)|r)?)?',
+  '(\\s*(\\d+)\\s*min(utes?)?)?',
+  '(\\s*(\\d+)\\s*s(ec(onds?)?)?)?',
+  '\\s*$'
+].join(''), 'i');
+
+
+/** Parse time string */
+var parseTime = function(str) {
+  // Parse the string
+  var match = timeExp.exec(str || '');
+  if (!match) {
+    throw new Error("String: '" + str + "' isn't a time expression");
+  }
+  // Negate if needed
+  var neg = (match[2] === '-' ? - 1 : 1);
+  // Return parsed values
+  return {
+    years:    parseInt(match[4]   || 0) * neg,
+    months:   parseInt(match[8]   || 0) * neg,
+    weeks:    parseInt(match[11]  || 0) * neg,
+    days:     parseInt(match[15]  || 0) * neg,
+    hours:    parseInt(match[18]  || 0) * neg,
+    minutes:  parseInt(match[22]  || 0) * neg,
+    seconds:  parseInt(match[25]  || 0) * neg
+  };
+};
+
+// Export parseTime
+module.exports = parseTime;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,55 +1,21 @@
 "use strict";
 
-// Regular expression matching:
-// A years B months C days D hours E minutes F seconds
-var timeExp = new RegExp([
-  '^(\\s*(-|\\+))?',
-  '(\\s*(\\d+)\\s*y((ears?)|r)?)?',
-  '(\\s*(\\d+)\\s*mo(nths?)?)?',
-  '(\\s*(\\d+)\\s*w((eeks?)|k)?)?',
-  '(\\s*(\\d+)\\s*d(ays?)?)?',
-  '(\\s*(\\d+)\\s*h((ours?)|r)?)?',
-  '(\\s*(\\d+)\\s*m(in(utes?)?)?)?',
-  '(\\s*(\\d+)\\s*s(ec(onds?)?)?)?',
-  '\\s*$'
-].join(''), 'i');
-
-
-/** Parse time string */
-var parseTime = function(str) {
-  // Parse the string
-  var match = timeExp.exec(str || '');
-  if (!match) {
-    throw new Error("String: '" + str + "' isn't a time expression");
-  }
-  // Negate if needed
-  var neg = (match[2] === '-' ? - 1 : 1);
-  // Return parsed values
-  return {
-    years:    parseInt(match[4]   || 0) * neg,
-    months:   parseInt(match[8]   || 0) * neg,
-    weeks:    parseInt(match[11]  || 0) * neg,
-    days:     parseInt(match[15]  || 0) * neg,
-    hours:    parseInt(match[18]  || 0) * neg,
-    minutes:  parseInt(match[22]  || 0) * neg,
-    seconds:  parseInt(match[26]  || 0) * neg
-  };
-};
-
-// Export parseTime
-exports.parseTime = parseTime;
+var parseTime = require('./parsetime');
 
 /**
- * Convert time offset object (from parseTime) to Date object relative to
- * reference.
+ * Create a Date object offset = '1d 2h 3min' into the future
+ *
+ * Offset format: The argument `offset` (if given) is a string on the form
+ *   `1 day 2 hours 3 minutes`
+ * where specification of day, hours and minutes is optional. You can also the
+ * short hand `1d2h3min`, it's fairly tolerant of different spelling forms and
+ * whitespace. But only really meant to be used with constants.
  */
-var relativeTime = function(offset, reference) {
+var fromNow = function(offset, reference) {
   if (reference === undefined) {
     reference = new Date();
   }
-  if (!offset || typeof(offset) === 'string') {
-    offset = parseTime(offset);
-  }
+  offset = parseTime(offset || '');
   var retval = new Date(
     reference.getTime()
     + offset.weeks   * 7 * 24 * 60 * 60 * 1000
@@ -67,11 +33,11 @@ var relativeTime = function(offset, reference) {
   return retval;
 };
 
-// Export relativeTime
-exports.relativeTime = relativeTime;
+// Export fromNow
+exports.fromNow = fromNow;
 
 /**
- * Create an ISO 8601 time stamp offset = '1d 2h 3m' into the future
+ * Create an ISO 8601 time stamp offset = '1d 2h 3min' into the future
  *
  * This returns a time stamp in the format expected by taskcluster.
  * Compatible with Date.toJSON() from Javascript. These time stamps are string
@@ -80,12 +46,12 @@ exports.relativeTime = relativeTime;
  * Offset format: The argument `offset` (if given) is a string on the form
  *   `1 day 2 hours 3 minutes`
  * where specification of day, hours and minutes is optional. You can also the
- * short hand `1d2h3m`, it's fairly tolerant of different spelling forms and
+ * short hand `1d2h3min`, it's fairly tolerant of different spelling forms and
  * whitespace. But only really meant to be used with constants.
  */
-var fromNow = function(offset) {
-  return relativeTime(offset).toJSON();
+var fromNowJSON = function(offset, reference) {
+  return fromNow(offset, reference).toJSON();
 };
 
-// Export fromNow
-exports.fromNow = fromNow;
+// Export fromNowJSON
+exports.fromNowJSON = fromNowJSON;

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -1,168 +1,156 @@
-suite('taskcluster.utils', function() {
+suite('taskcluster utilities', function() {
   var taskcluster       = require('../');
+  var parseTime         = require('../lib/parsetime');
   var assert            = require('assert');
 
   test('parseTime 1 year', function() {
-    assert.equal(taskcluster.utils.parseTime('1y').years, 1);
-    assert.equal(taskcluster.utils.parseTime('1 yr').years, 1);
-    assert.equal(taskcluster.utils.parseTime('1 year').years, 1);
-    assert.equal(taskcluster.utils.parseTime('1 years').years, 1);
-    assert.equal(taskcluster.utils.parseTime('1year').years, 1);
-    assert.equal(taskcluster.utils.parseTime('1    yr').years, 1);
-    assert.equal(taskcluster.utils.parseTime('  1    year   ').years, 1);
-    assert.equal(taskcluster.utils.parseTime('  1 years   ').years, 1);
+    assert.equal(parseTime('1y').years, 1);
+    assert.equal(parseTime('1 yr').years, 1);
+    assert.equal(parseTime('1 year').years, 1);
+    assert.equal(parseTime('1 years').years, 1);
+    assert.equal(parseTime('1year').years, 1);
+    assert.equal(parseTime('1    yr').years, 1);
+    assert.equal(parseTime('  1    year   ').years, 1);
+    assert.equal(parseTime('  1 years   ').years, 1);
   });
 
   test('parseTime -1 year', function() {
-    assert.equal(taskcluster.utils.parseTime('- 1y').years, -1);
-    assert.equal(taskcluster.utils.parseTime('- 1 yr').years, -1);
-    assert.equal(taskcluster.utils.parseTime('- 1 year').years, -1);
-    assert.equal(taskcluster.utils.parseTime('- 1 years').years, -1);
-    assert.equal(taskcluster.utils.parseTime('- 1year').years, -1);
-    assert.equal(taskcluster.utils.parseTime('- 1    yr').years, -1);
-    assert.equal(taskcluster.utils.parseTime('  - 1    year   ').years, -1);
-    assert.equal(taskcluster.utils.parseTime('  -  1 years   ').years, -1);
+    assert.equal(parseTime('- 1y').years, -1);
+    assert.equal(parseTime('- 1 yr').years, -1);
+    assert.equal(parseTime('- 1 year').years, -1);
+    assert.equal(parseTime('- 1 years').years, -1);
+    assert.equal(parseTime('- 1year').years, -1);
+    assert.equal(parseTime('- 1    yr').years, -1);
+    assert.equal(parseTime('  - 1    year   ').years, -1);
+    assert.equal(parseTime('  -  1 years   ').years, -1);
   });
 
   test('parseTime +1 year', function() {
-    assert.equal(taskcluster.utils.parseTime('+ 1y').years, 1);
-    assert.equal(taskcluster.utils.parseTime('+ 1 yr').years, 1);
-    assert.equal(taskcluster.utils.parseTime('+ 1 year').years, 1);
-    assert.equal(taskcluster.utils.parseTime('+ 1 years').years, 1);
-    assert.equal(taskcluster.utils.parseTime('+ 1year').years, 1);
-    assert.equal(taskcluster.utils.parseTime('+ 1    yr').years, 1);
-    assert.equal(taskcluster.utils.parseTime('  + 1    year   ').years, 1);
-    assert.equal(taskcluster.utils.parseTime('  +  1 years   ').years, 1);
+    assert.equal(parseTime('+ 1y').years, 1);
+    assert.equal(parseTime('+ 1 yr').years, 1);
+    assert.equal(parseTime('+ 1 year').years, 1);
+    assert.equal(parseTime('+ 1 years').years, 1);
+    assert.equal(parseTime('+ 1year').years, 1);
+    assert.equal(parseTime('+ 1    yr').years, 1);
+    assert.equal(parseTime('  + 1    year   ').years, 1);
+    assert.equal(parseTime('  +  1 years   ').years, 1);
   });
 
   test('parseTime 1 month', function() {
-    assert.equal(taskcluster.utils.parseTime('1mo').months, 1);
-    assert.equal(taskcluster.utils.parseTime('1 mo').months, 1);
-    assert.equal(taskcluster.utils.parseTime('1 month').months, 1);
-    assert.equal(taskcluster.utils.parseTime('1 months').months, 1);
-    assert.equal(taskcluster.utils.parseTime('1month').months, 1);
-    assert.equal(taskcluster.utils.parseTime('1    mo').months, 1);
-    assert.equal(taskcluster.utils.parseTime('  1    month   ').months, 1);
-    assert.equal(taskcluster.utils.parseTime('  1 months   ').months, 1);
+    assert.equal(parseTime('1mo').months, 1);
+    assert.equal(parseTime('1 mo').months, 1);
+    assert.equal(parseTime('1 month').months, 1);
+    assert.equal(parseTime('1 months').months, 1);
+    assert.equal(parseTime('1month').months, 1);
+    assert.equal(parseTime('1    mo').months, 1);
+    assert.equal(parseTime('  1    month   ').months, 1);
+    assert.equal(parseTime('  1 months   ').months, 1);
   });
 
   test('parseTime -1 month', function() {
-    assert.equal(taskcluster.utils.parseTime('- 1mo').months, -1);
-    assert.equal(taskcluster.utils.parseTime('- 1 mo').months, -1);
-    assert.equal(taskcluster.utils.parseTime('- 1 month').months, -1);
-    assert.equal(taskcluster.utils.parseTime('- 1 months').months, -1);
-    assert.equal(taskcluster.utils.parseTime('- 1month').months, -1);
-    assert.equal(taskcluster.utils.parseTime('- 1    mo').months, -1);
-    assert.equal(taskcluster.utils.parseTime('  - 1    month   ').months, -1);
-    assert.equal(taskcluster.utils.parseTime('  - 1 months   ').months, -1);
+    assert.equal(parseTime('- 1mo').months, -1);
+    assert.equal(parseTime('- 1 mo').months, -1);
+    assert.equal(parseTime('- 1 month').months, -1);
+    assert.equal(parseTime('- 1 months').months, -1);
+    assert.equal(parseTime('- 1month').months, -1);
+    assert.equal(parseTime('- 1    mo').months, -1);
+    assert.equal(parseTime('  - 1    month   ').months, -1);
+    assert.equal(parseTime('  - 1 months   ').months, -1);
   });
 
   test('parseTime 1 week', function() {
-    assert.equal(taskcluster.utils.parseTime('1w').weeks, 1);
-    assert.equal(taskcluster.utils.parseTime('1 wk').weeks, 1);
-    assert.equal(taskcluster.utils.parseTime('1 week').weeks, 1);
-    assert.equal(taskcluster.utils.parseTime('1 weeks').weeks, 1);
-    assert.equal(taskcluster.utils.parseTime('1week').weeks, 1);
-    assert.equal(taskcluster.utils.parseTime('1    wk').weeks, 1);
-    assert.equal(taskcluster.utils.parseTime('  1    week   ').weeks, 1);
-    assert.equal(taskcluster.utils.parseTime('  1 weeks   ').weeks, 1);
+    assert.equal(parseTime('1w').weeks, 1);
+    assert.equal(parseTime('1 wk').weeks, 1);
+    assert.equal(parseTime('1 week').weeks, 1);
+    assert.equal(parseTime('1 weeks').weeks, 1);
+    assert.equal(parseTime('1week').weeks, 1);
+    assert.equal(parseTime('1    wk').weeks, 1);
+    assert.equal(parseTime('  1    week   ').weeks, 1);
+    assert.equal(parseTime('  1 weeks   ').weeks, 1);
   });
 
   test('parseTime 1 day', function() {
-    assert.equal(taskcluster.utils.parseTime('1d').days, 1);
-    assert.equal(taskcluster.utils.parseTime('1 d').days, 1);
-    assert.equal(taskcluster.utils.parseTime('1 day').days, 1);
-    assert.equal(taskcluster.utils.parseTime('1 days').days, 1);
-    assert.equal(taskcluster.utils.parseTime('1day').days, 1);
-    assert.equal(taskcluster.utils.parseTime('1    d').days, 1);
-    assert.equal(taskcluster.utils.parseTime('  1    day   ').days, 1);
-    assert.equal(taskcluster.utils.parseTime('  1 days   ').days, 1);
+    assert.equal(parseTime('1d').days, 1);
+    assert.equal(parseTime('1 d').days, 1);
+    assert.equal(parseTime('1 day').days, 1);
+    assert.equal(parseTime('1 days').days, 1);
+    assert.equal(parseTime('1day').days, 1);
+    assert.equal(parseTime('1    d').days, 1);
+    assert.equal(parseTime('  1    day   ').days, 1);
+    assert.equal(parseTime('  1 days   ').days, 1);
   });
 
   test('parseTime 3 days', function() {
-    assert.equal(taskcluster.utils.parseTime('3d').days, 3);
-    assert.equal(taskcluster.utils.parseTime('3 d').days, 3);
-    assert.equal(taskcluster.utils.parseTime('3 day').days, 3);
-    assert.equal(taskcluster.utils.parseTime('3 days').days, 3);
-    assert.equal(taskcluster.utils.parseTime('3day').days, 3);
-    assert.equal(taskcluster.utils.parseTime('3    d').days, 3);
-    assert.equal(taskcluster.utils.parseTime('  3    day   ').days, 3);
-    assert.equal(taskcluster.utils.parseTime('  3 days   ').days, 3);
+    assert.equal(parseTime('3d').days, 3);
+    assert.equal(parseTime('3 d').days, 3);
+    assert.equal(parseTime('3 day').days, 3);
+    assert.equal(parseTime('3 days').days, 3);
+    assert.equal(parseTime('3day').days, 3);
+    assert.equal(parseTime('3    d').days, 3);
+    assert.equal(parseTime('  3    day   ').days, 3);
+    assert.equal(parseTime('  3 days   ').days, 3);
   });
 
   test('parseTime 45 hours', function() {
-    assert.equal(taskcluster.utils.parseTime('45h').hours, 45);
-    assert.equal(taskcluster.utils.parseTime('45 h').hours, 45);
-    assert.equal(taskcluster.utils.parseTime('45 hour').hours, 45);
-    assert.equal(taskcluster.utils.parseTime('45 hours').hours, 45);
-    assert.equal(taskcluster.utils.parseTime('45hours').hours, 45);
-    assert.equal(taskcluster.utils.parseTime('45    h').hours, 45);
-    assert.equal(taskcluster.utils.parseTime('  45    hour   ').hours, 45);
-    assert.equal(taskcluster.utils.parseTime('  45 hours   ').hours, 45);
+    assert.equal(parseTime('45h').hours, 45);
+    assert.equal(parseTime('45 h').hours, 45);
+    assert.equal(parseTime('45 hour').hours, 45);
+    assert.equal(parseTime('45 hours').hours, 45);
+    assert.equal(parseTime('45hours').hours, 45);
+    assert.equal(parseTime('45    h').hours, 45);
+    assert.equal(parseTime('  45    hour   ').hours, 45);
+    assert.equal(parseTime('  45 hours   ').hours, 45);
   });
 
   test('parseTime 45 min', function() {
-    assert.equal(taskcluster.utils.parseTime('45m').minutes, 45);
-    assert.equal(taskcluster.utils.parseTime('45 m').minutes, 45);
-    assert.equal(taskcluster.utils.parseTime('45 min').minutes, 45);
-    assert.equal(taskcluster.utils.parseTime('45 minute').minutes, 45);
-    assert.equal(taskcluster.utils.parseTime('45 minutes').minutes, 45);
-    assert.equal(taskcluster.utils.parseTime('45minutes').minutes, 45);
-    assert.equal(taskcluster.utils.parseTime('45    m').minutes, 45);
-    assert.equal(taskcluster.utils.parseTime('  45    min   ').minutes, 45);
-    assert.equal(taskcluster.utils.parseTime('  45 minutes   ').minutes, 45);
+    assert.equal(parseTime('45min').minutes, 45);
+    assert.equal(parseTime('45 min').minutes, 45);
+    assert.equal(parseTime('45 minute').minutes, 45);
+    assert.equal(parseTime('45 minutes').minutes, 45);
+    assert.equal(parseTime('45minutes').minutes, 45);
+    assert.equal(parseTime('45    min').minutes, 45);
+    assert.equal(parseTime('  45    min   ').minutes, 45);
+    assert.equal(parseTime('  45 minutes   ').minutes, 45);
   });
 
   test('parseTime 45 seconds', function() {
-    assert.equal(taskcluster.utils.parseTime('45 s').seconds, 45);
-    assert.equal(taskcluster.utils.parseTime('45 s').seconds, 45);
-    assert.equal(taskcluster.utils.parseTime('45 sec').seconds, 45);
-    assert.equal(taskcluster.utils.parseTime('45 second').seconds, 45);
-    assert.equal(taskcluster.utils.parseTime('45 seconds').seconds, 45);
-    assert.equal(taskcluster.utils.parseTime('45seconds').seconds, 45);
-    assert.equal(taskcluster.utils.parseTime('45    s').seconds, 45);
-    assert.equal(taskcluster.utils.parseTime('  45    sec   ').seconds, 45);
-    assert.equal(taskcluster.utils.parseTime('  45 seconds   ').seconds, 45);
+    assert.equal(parseTime('45 s').seconds, 45);
+    assert.equal(parseTime('45 s').seconds, 45);
+    assert.equal(parseTime('45 sec').seconds, 45);
+    assert.equal(parseTime('45 second').seconds, 45);
+    assert.equal(parseTime('45 seconds').seconds, 45);
+    assert.equal(parseTime('45seconds').seconds, 45);
+    assert.equal(parseTime('45    s').seconds, 45);
+    assert.equal(parseTime('  45    sec   ').seconds, 45);
+    assert.equal(parseTime('  45 seconds   ').seconds, 45);
   });
 
-  test('parseTime 1yr2mo3w4d5h6m7s', function() {
-    assert.equal(taskcluster.utils.parseTime('1yr2mo3w4d5h6m7s').years, 1);
-    assert.equal(taskcluster.utils.parseTime('1yr2mo3w4d5h6m7s').months, 2);
-    assert.equal(taskcluster.utils.parseTime('1yr2mo3w4d5h6m7s').weeks, 3);
-    assert.equal(taskcluster.utils.parseTime('1yr2mo3w4d5h6m7s').days, 4);
-    assert.equal(taskcluster.utils.parseTime('1yr2mo3w4d5h6m7s').hours, 5);
-    assert.equal(taskcluster.utils.parseTime('1yr2mo3w4d5h6m7s').minutes, 6);
-    assert.equal(taskcluster.utils.parseTime('1yr2mo3w4d5h6m7s').seconds, 7);
-    assert.equal(taskcluster.utils.parseTime('2d3h').minutes, 0);
-    assert.equal(taskcluster.utils.parseTime('2d0h').hours, 0);
+  test('parseTime 1yr2mo3w4d5h6min7s', function() {
+    assert.equal(parseTime('1yr2mo3w4d5h6min7s').years, 1);
+    assert.equal(parseTime('1yr2mo3w4d5h6min7s').months, 2);
+    assert.equal(parseTime('1yr2mo3w4d5h6min7s').weeks, 3);
+    assert.equal(parseTime('1yr2mo3w4d5h6min7s').days, 4);
+    assert.equal(parseTime('1yr2mo3w4d5h6min7s').hours, 5);
+    assert.equal(parseTime('1yr2mo3w4d5h6min7s').minutes, 6);
+    assert.equal(parseTime('1yr2mo3w4d5h6min7s').seconds, 7);
+    assert.equal(parseTime('2d3h').minutes, 0);
+    assert.equal(parseTime('2d0h').hours, 0);
   });
-  test('parseTime -1yr2mo3w4d5h6m7s', function() {
-    assert.equal(taskcluster.utils.parseTime('-1yr2mo3w4d5h6m7s').years, -1);
-    assert.equal(taskcluster.utils.parseTime('-1yr2mo3w4d5h6m7s').months, -2);
-    assert.equal(taskcluster.utils.parseTime('-1yr2mo3w4d5h6m7s').weeks, -3);
-    assert.equal(taskcluster.utils.parseTime('-1yr2mo3w4d5h6m7s').days, -4);
-    assert.equal(taskcluster.utils.parseTime('-1yr2mo3w4d5h6m7s').hours, -5);
-    assert.equal(taskcluster.utils.parseTime('-1yr2mo3w4d5h6m7s').minutes, -6);
-    assert.equal(taskcluster.utils.parseTime('-1yr2mo3w4d5h6m7s').seconds, -7);
-    assert.equal(taskcluster.utils.parseTime('-2d3h').minutes, 0);
-    assert.equal(taskcluster.utils.parseTime('-2d0h').hours, 0);
-  });
-
-  test('relativeTime', function() {
-    var d1 = new Date();
-    var d2 = new Date(d1.getTime());
-    d2.setHours(d1.getHours() + 2);
-    var d3 = taskcluster.utils.relativeTime(
-      taskcluster.utils.parseTime('2 hours'),
-      d1
-    );
-    assert(d3.getTime() === d2.getTime(), "Wrong date");
+  test('parseTime -1yr2mo3w4d5h6min7s', function() {
+    assert.equal(parseTime('-1yr2mo3w4d5h6min7s').years, -1);
+    assert.equal(parseTime('-1yr2mo3w4d5h6min7s').months, -2);
+    assert.equal(parseTime('-1yr2mo3w4d5h6min7s').weeks, -3);
+    assert.equal(parseTime('-1yr2mo3w4d5h6min7s').days, -4);
+    assert.equal(parseTime('-1yr2mo3w4d5h6min7s').hours, -5);
+    assert.equal(parseTime('-1yr2mo3w4d5h6min7s').minutes, -6);
+    assert.equal(parseTime('-1yr2mo3w4d5h6min7s').seconds, -7);
+    assert.equal(parseTime('-2d3h').minutes, 0);
+    assert.equal(parseTime('-2d0h').hours, 0);
   });
 
   test('fromNow()', function() {
     var d1 = new Date();
-    var ts = taskcluster.utils.fromNow();
-    var d2 = new Date(ts);
+    var d2 = taskcluster.fromNow();
 
     // Allow for 10 ms margin
     assert(Math.abs(d2.getTime() - d1.getTime()) <= 10);
@@ -171,8 +159,7 @@ suite('taskcluster.utils', function() {
   test('fromNow(2 hours)', function() {
     var d1 = new Date();
     d1.setHours(d1.getHours() + 2)
-    var ts = taskcluster.utils.fromNow('2 hours');
-    var d2 = new Date(ts);
+    var d2 = taskcluster.fromNow('2 hours');
 
     // Allow for 10 ms margin
     assert(Math.abs(d2.getTime() - d1.getTime()) <= 10);
@@ -181,8 +168,7 @@ suite('taskcluster.utils', function() {
   test('fromNow(2 years 15 months)', function() {
     var d1 = new Date();
     d1.setMonth(d1.getMonth() + 12 * 2 + 15)
-    var ts = taskcluster.utils.fromNow('2 years 15mo');
-    var d2 = new Date(ts);
+    var d2 = taskcluster.fromNow('2 years 15mo');
 
     // Allow for 10ms margin
     assert(Math.abs(d2.getTime() - d1.getTime()) <= 10);
@@ -191,8 +177,7 @@ suite('taskcluster.utils', function() {
   test('fromNow(2 years 55 months)', function() {
     var d1 = new Date();
     d1.setMonth(d1.getMonth() + 12 * 2 + 55)
-    var ts = taskcluster.utils.fromNow('2 years 55mo');
-    var d2 = new Date(ts);
+    var d2 = taskcluster.fromNow('2 years 55mo');
 
     // Allow for 10ms margin
     assert(Math.abs(d2.getTime() - d1.getTime()) <= 10);
@@ -201,8 +186,7 @@ suite('taskcluster.utils', function() {
   test('fromNow(240 months)', function() {
     var d1 = new Date();
     d1.setFullYear(d1.getFullYear() + 20)
-    var ts = taskcluster.utils.fromNow('240 months');
-    var d2 = new Date(ts);
+    var d2 = taskcluster.fromNow('240 months');
 
     // Allow for 10ms margin
     assert(Math.abs(d2.getTime() - d1.getTime()) <= 10);
@@ -211,8 +195,7 @@ suite('taskcluster.utils', function() {
   test('fromNow(-240 months)', function() {
     var d1 = new Date();
     d1.setFullYear(d1.getFullYear() - 20)
-    var ts = taskcluster.utils.fromNow('-240 months');
-    var d2 = new Date(ts);
+    var d2 = taskcluster.fromNow('-240 months');
 
     // Allow for 10ms margin
     assert(Math.abs(d2.getTime() - d1.getTime()) <= 10);
@@ -221,8 +204,7 @@ suite('taskcluster.utils', function() {
   test('fromNow(20 years)', function() {
     var d1 = new Date();
     d1.setFullYear(d1.getFullYear() + 20)
-    var ts = taskcluster.utils.fromNow('20 years');
-    var d2 = new Date(ts);
+    var d2 = taskcluster.fromNow('20 years');
 
     // Allow for 10ms margin
     assert(Math.abs(d2.getTime() - d1.getTime()) <= 10);


### PR DESCRIPTION
 * Removed `utils` namespace
 * Renamed `fromNow` to `fromNowJSON` and `relativeTime` to `fromNow`
 * Made `m` invalid for minute
 * Added lots of docs...

See: https://bugzilla.mozilla.org/show_bug.cgi?id=1134266

