### PR TITLE
Minor error in one of the code examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ var queue = new taskcluster.Queue({
 
 // Create task using the queue client
 var taskId = '...';
-queue.createTask(taskId, task).then(function(result) {
+queue.createTask(taskId, payload).then(function(result) {
   // status is a task status structure
   console.log(result.status);
 });


### PR DESCRIPTION
Code example in https://github.com/taskcluster/taskcluster-client#calling-api-end-points uses the term 'task', but the explanatory text below it uses 'payload'. Fixed in accordance with http://docs.taskcluster.net/queue/api-docs/