### PR TITLE
Include utils in browserify version

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -9,7 +9,8 @@ var SockJS  = require('./lib/sockjs');
 // cannot be supported by browserify
 var taskcluster = _.defaults({},
   require('./lib/client'),
-  require('./lib/weblistener')
+  require('./lib/weblistener'),
+  require('./lib/utils')
 );
 
 // Provide a SockJS client implementation for the WebListener


### PR DESCRIPTION
This will expose methods defined in `utils.js` on `taskcluster` in the browser the same way they are in the client... Pretty trivial...

Mostly assigning you to keep you updated... Let me know if you see any issues with this..
If I don't hear anything I'll land this tomorrow and publish it.