### PR TITLE
Bumped release, so we can republish to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name":         "taskcluster-client",
-  "version":      "0.22.6",
+  "version":      "0.23.1",
   "author":       "Jonas Finnemann Jensen <jopsen@gmail.com>",
   "description":  "Client for interfacing taskcluster components",
   "license":      "MPL-2.0",


### PR DESCRIPTION
... so we can use the new version in gaia with 'nice' slugs!