### PR TITLE
Credential utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,6 +661,38 @@ var dateObject2 = taskcluster.fromNow("1 year", dateObject1);
 // dateObject2  = now() + 1 year, 2 days and 3 hours
 ```
 
+## Handling Credentials
+
+Your users may find the options for TaskCluster credentials overwhelming.  You
+can help by interpreting the credentials for them.
+
+The `credentialInformation(credentials, options)` function returns a promise
+with information about the given credentials:
+
+```js
+{
+   clientId: "..",      // name of the credential
+   type: "..",          // type of credential, e.g., "temporary"
+   active: "..",        // active (valid, not disabled, etc.)
+   start: "..",         // validity start time (if applicable)
+   expiry: "..",        // validity end time (if applicable)
+   scopes: ["..."],     // associated scopes (if available)
+}
+```
+
+The resulting information should *only* be used for presentation purposes, and
+never for access control.  This function may fail unexpectedly with invalid
+credentials, and performs no cryptographic checks.  It is acceptable to use the
+scopes result to determine whether to display UI elements associated with a
+particular scope, as long as the underlying API performs more reliable
+authorization checks.
+
+If `options.localOnly` is true, then no network traffic is generated.  This may
+reduce the amount of information available.  If `localOnly` is not true, then
+the credential is used to make requests to the auth service to get accurate and
+up-to-date information.  In this case, the scopes information is particularly
+unreliable and should not even be used for UI element display.
+
 ## Generating slugids
 In node you can rely on the `slugid` module to generate slugids, but we already
 need it in `taskcluster-client` and expose the preferred slugid generation

--- a/README.md
+++ b/README.md
@@ -687,12 +687,6 @@ scopes result to determine whether to display UI elements associated with a
 particular scope, as long as the underlying API performs more reliable
 authorization checks.
 
-If `options.localOnly` is true, then no network traffic is generated.  This may
-reduce the amount of information available.  If `localOnly` is not true, then
-the credential is used to make requests to the auth service to get accurate and
-up-to-date information.  In this case, the scopes information is particularly
-unreliable and should not even be used for UI element display.
-
 ## Generating slugids
 In node you can rely on the `slugid` module to generate slugids, but we already
 need it in `taskcluster-client` and expose the preferred slugid generation

--- a/lib/client.js
+++ b/lib/client.js
@@ -734,11 +734,6 @@ exports.createTemporaryCredentials = function(options) {
  *   certificate,           // optional
  * }
  *
- * options:
- * {
- *   localOnly: true,       // do not make network requests
- * }
- *
  * result: Promise for
  * {
  *    clientId: ..,         // name of the credential
@@ -749,8 +744,7 @@ exports.createTemporaryCredentials = function(options) {
  *    scopes: [...],        // associated scopes (if available)
  * }
  */
-exports.credentialInformation = function(credentials, options) {
-  var localOnly = options && options.localOnly;
+exports.credentialInformation = function(credentials) {
   var result = {};
   var issuer = credentials.clientId; 
 
@@ -777,31 +771,23 @@ exports.credentialInformation = function(credentials, options) {
     result.type = "permanent";
   }
 
-  // that's all we can tell without network
-  var nonlocalWork;
-  if (localOnly) {
-    nonlocalWork = Promise.resolve();
-  } else {
-    var anonClient = new exports.Auth();
-    var clientLookup = anonClient.client(issuer).then(function(client) {
-      var expires = new Date(client.expires);
-      if (!result.expiry || result.expiry > expires) {
-        result.expiry = expires;
-      }
-      if (client.disabled) {
-        result.active = false;
-      }
-    });
+  var anonClient = new exports.Auth();
+  var clientLookup = anonClient.client(issuer).then(function(client) {
+    var expires = new Date(client.expires);
+    if (!result.expiry || result.expiry > expires) {
+      result.expiry = expires;
+    }
+    if (client.disabled) {
+      result.active = false;
+    }
+  });
 
-    var credClient = new exports.Auth({credentials});
-    var scopeLookup = credClient.currentScopes().then(function(response) {
-      result.scopes = response.scopes;
-    });
+  var credClient = new exports.Auth({credentials});
+  var scopeLookup = credClient.currentScopes().then(function(response) {
+    result.scopes = response.scopes;
+  });
 
-    nonlocalWork = Promise.all([clientLookup, scopeLookup])
-  }
-
-  return nonlocalWork.then(function() {
+  return Promise.all([clientLookup, scopeLookup]).then(function() {
     // re-calculate "active" based on updated start/expiration
     var now = new Date();
     if (result.start && result.start > now) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -724,3 +724,92 @@ exports.createTemporaryCredentials = function(options) {
     certificate:  JSON.stringify(cert)
   };
 };
+
+/**
+ * Get information about a set of credentials.
+ *
+ * credentials: {
+ *   clientId,
+ *   accessToken,
+ *   certificate,           // optional
+ * }
+ *
+ * options:
+ * {
+ *   localOnly: true,       // do not make network requests
+ * }
+ *
+ * result: Promise for
+ * {
+ *    clientId: ..,         // name of the credential
+ *    type: ..,             // type of credential, e.g., "temporary"
+ *    active: ..,           // active (valid, not disabled, etc.)
+ *    start: ..,            // validity start time (if applicable)
+ *    expiry: ..,           // validity end time (if applicable)
+ *    scopes: [...],        // associated scopes (if available)
+ * }
+ */
+exports.credentialInformation = function(credentials, options) {
+  var localOnly = options && options.localOnly;
+  var result = {};
+  var issuer = credentials.clientId; 
+
+  result.clientId = issuer;
+  result.active = true;
+
+  // distinguish permacreds from temporary creds
+  if (credentials.certificate) {
+    result.type = "temporary";
+    var cert;
+    try {
+      cert = JSON.parse(credentials.certificate);
+    } catch (err) {
+      return Promise.reject(err);
+    }
+    result.scopes = cert.scopes;
+    result.start = new Date(cert.start);
+    result.expiry = new Date(cert.expiry);
+
+    if (cert.issuer) {
+      issuer = cert.issuer;
+    }
+  } else {
+    result.type = "permanent";
+  }
+
+  // that's all we can tell without network
+  var nonlocalWork;
+  if (localOnly) {
+    nonlocalWork = Promise.resolve();
+  } else {
+    var anonClient = new exports.Auth();
+    var clientLookup = anonClient.client(issuer).then(function(client) {
+      var expires = new Date(client.expires);
+      if (!result.expiry || result.expiry > expires) {
+        result.expiry = expires;
+      }
+      if (client.disabled) {
+        result.active = false;
+      }
+    });
+
+    var credClient = new exports.Auth({credentials});
+    var scopeLookup = credClient.currentScopes().then(function(response) {
+      result.scopes = response.scopes;
+    });
+
+    nonlocalWork = Promise.all([clientLookup, scopeLookup])
+  }
+
+  return nonlocalWork.then(function() {
+    // re-calculate "active" based on updated start/expiration
+    var now = new Date();
+    if (result.start && result.start > now) {
+      result.active = false;
+    } else if (result.expiry && now > result.expiry) {
+      result.active = false;
+    }
+
+    return result;
+  });
+};

--- a/test/credinfo_test.js
+++ b/test/credinfo_test.js
@@ -1,0 +1,177 @@
+suite('taskcluster.credentialInfo', function() {
+  var taskcluster     = require('../');
+  var assert          = require('assert');
+  var nock            = require('nock');
+
+  teardown(function() {
+    let pending = nock.pendingMocks();
+    assert.deepEqual(pending, []);
+  });
+
+  var setupNocks = function(options) {
+    options = options || {};
+    var client = {
+      clientId: "clid",
+      description: "TEST",
+      expires: options.expires || "2100-02-17T05:00:00.000Z",
+      created: "2016-02-15T12:59:53.371Z",
+      lastModified: "2016-02-15T20:26:14.896Z",
+      lastDateUsed: "2016-02-15T12:59:53.371Z",
+      lastRotated: "2016-02-15T12:59:53.371Z",
+      scopes: ["*"],
+      expandedScopes: ["*"],
+      disabled: !!options.disabled,
+    };
+    nock('https://auth.taskcluster.net').get('/v1/clients/clid')
+      .reply(200, client);
+    nock('https://auth.taskcluster.net').get('/v1/scopes/current')
+      .reply(200, {scopes: options.scopes || []});
+  };
+
+  test("permanent", async function() {
+    setupNocks({scopes: ['scope1']});
+    assert.deepEqual(
+      await taskcluster.credentialInformation({clientId: "clid"}), {
+        active: true,
+        clientId: "clid",
+        type: "permanent",
+        scopes: ['scope1'],
+        expiry: new Date("2100-02-17T05:00:00.000Z"),
+      })
+  });
+
+  test("permanent, expired", async function() {
+    setupNocks({
+      expires: "2000-12-31T23:59:59.999Z",
+      scopes: ['scope1'],
+    })
+    assert.deepEqual(
+      await taskcluster.credentialInformation({clientId: "clid"}), {
+        active: false,
+        clientId: "clid",
+        type: "permanent",
+        scopes: ['scope1'],
+        expiry: new Date("2000-12-31T23:59:59.999Z"),
+      })
+  });
+
+  test("permanent, disabled", async function() {
+    setupNocks({
+      disabled: true,
+      scopes: ['scope1', 'scope2'],
+    });
+    assert.deepEqual(
+      await taskcluster.credentialInformation({clientId: "clid"}), {
+        active: false,
+        clientId: "clid",
+        type: "permanent",
+        scopes: ['scope1', 'scope2'],
+        expiry: new Date("2100-02-17T05:00:00.000Z"),
+      })
+  });
+
+  test("permanent, localOnly", async function() {
+    assert.deepEqual(
+      await taskcluster.credentialInformation({clientId: "clid"}, {localOnly: true}), {
+        active: true,
+        clientId: "clid",
+        type: "permanent",
+      })
+  });
+
+  test("temporary", async function() {
+    var start = taskcluster.fromNow("-1 hour");
+    var expiry = taskcluster.fromNow("1 hour");
+    var scopes = ['scope1', 'scope2'];
+    var credentials = taskcluster.createTemporaryCredentials({
+      start, expiry, scopes,
+      credentials: {
+        clientId: 'clid',
+        accessToken: 'no-secret',
+      },
+    });
+
+    setupNocks({scopes: scopes});
+    assert.deepEqual(
+      await taskcluster.credentialInformation(credentials), {
+        active: true,
+        clientId: "clid",
+        type: "temporary",
+        scopes: scopes,
+        start,
+        expiry,
+      })
+  });
+
+  test("temporary, expires after issuer", async function() {
+    var start = taskcluster.fromNow("-1 hour");
+    var expiry = taskcluster.fromNow("2 days");
+    var scopes = ['scope1', 'scope2'];
+    var credentials = taskcluster.createTemporaryCredentials({
+      start, expiry, scopes,
+      credentials: {
+        clientId: 'clid',
+        accessToken: 'no-secret',
+      },
+    });
+
+    var permaExpiry = taskcluster.fromNow("1 day");
+    setupNocks({expires: permaExpiry.toJSON(), scopes});
+    assert.deepEqual(
+      await taskcluster.credentialInformation(credentials), {
+        active: true,
+        clientId: "clid",
+        type: "temporary",
+        scopes: scopes,
+        start,
+        expiry: permaExpiry,
+      })
+  });
+
+  test("temporary, localOnly", async function() {
+    var start = taskcluster.fromNow("-1 hour");
+    var expiry = taskcluster.fromNow("1 hour");
+    var scopes = ['scope1', 'scope2'];
+    var credentials = taskcluster.createTemporaryCredentials({
+      start, expiry, scopes,
+      credentials: {
+        clientId: 'issuer',
+        accessToken: 'no-secret',
+      },
+    });
+
+    assert.deepEqual(
+      await taskcluster.credentialInformation(credentials, {localOnly: true}), {
+        active: true,
+        clientId: "issuer",
+        type: "temporary",
+        scopes: scopes,
+        start,
+        expiry,
+      })
+  });
+
+  test("named temporary, localOnly", async function() {
+    var start = taskcluster.fromNow("-1 hour");
+    var expiry = taskcluster.fromNow("1 hour");
+    var scopes = ['scope1', 'scope2'];
+    var credentials = taskcluster.createTemporaryCredentials({
+      start, expiry, scopes,
+      clientId: 'my-name',
+      credentials: {
+        clientId: 'issuer',
+        accessToken: 'no-secret',
+      },
+    });
+
+    assert.deepEqual(
+      await taskcluster.credentialInformation(credentials, {localOnly: true}), {
+        active: true,
+        clientId: "my-name",
+        type: "temporary",
+        scopes: scopes,
+        start,
+        expiry,
+      })
+  });
+});

--- a/test/credinfo_test.js
+++ b/test/credinfo_test.js
@@ -70,15 +70,6 @@ suite('taskcluster.credentialInfo', function() {
       })
   });
 
-  test("permanent, localOnly", async function() {
-    assert.deepEqual(
-      await taskcluster.credentialInformation({clientId: "clid"}, {localOnly: true}), {
-        active: true,
-        clientId: "clid",
-        type: "permanent",
-      })
-  });
-
   test("temporary", async function() {
     var start = taskcluster.fromNow("-1 hour");
     var expiry = taskcluster.fromNow("1 hour");
@@ -125,53 +116,6 @@ suite('taskcluster.credentialInfo', function() {
         scopes: scopes,
         start,
         expiry: permaExpiry,
-      })
-  });
-
-  test("temporary, localOnly", async function() {
-    var start = taskcluster.fromNow("-1 hour");
-    var expiry = taskcluster.fromNow("1 hour");
-    var scopes = ['scope1', 'scope2'];
-    var credentials = taskcluster.createTemporaryCredentials({
-      start, expiry, scopes,
-      credentials: {
-        clientId: 'issuer',
-        accessToken: 'no-secret',
-      },
-    });
-
-    assert.deepEqual(
-      await taskcluster.credentialInformation(credentials, {localOnly: true}), {
-        active: true,
-        clientId: "issuer",
-        type: "temporary",
-        scopes: scopes,
-        start,
-        expiry,
-      })
-  });
-
-  test("named temporary, localOnly", async function() {
-    var start = taskcluster.fromNow("-1 hour");
-    var expiry = taskcluster.fromNow("1 hour");
-    var scopes = ['scope1', 'scope2'];
-    var credentials = taskcluster.createTemporaryCredentials({
-      start, expiry, scopes,
-      clientId: 'my-name',
-      credentials: {
-        clientId: 'issuer',
-        accessToken: 'no-secret',
-      },
-    });
-
-    assert.deepEqual(
-      await taskcluster.credentialInformation(credentials, {localOnly: true}), {
-        active: true,
-        clientId: "my-name",
-        type: "temporary",
-        scopes: scopes,
-        start,
-        expiry,
       })
   });
 });


### PR DESCRIPTION
I have plans for all of this!

In the tools site, I want to periodically refresh the credential information, to get the user's clientId, to better determine when the user is logged out, and to allow the user to easily see their own scopes.  I'd like to go with the option of allowing multiple credentials and switching between them, so this information will help distinguish the credentials.

As for the ascii-armoring, I'd like to provide an "export" option for new clients (in addition to revealing the accessToken), and both "import" and "export" options in the credential UI.  I see this being used to set up command-line clients, to copy credentials between browsers, and to send credentials to other users (hopefully via GPG, but that's beyond my control -- at least I added the "Caution" header).