### PR TITLE
Use testAuthenticateGet

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ var auth = new taskcluster.Auth(options);
  * `auth.azureTableSAS(account, table) : result`
  * `auth.authenticateHawk(payload) : result`
  * `auth.testAuthenticate(payload) : result`
+ * `auth.testAuthenticateGet() : result`
  * `auth.ping() : void`
 
 ### Methods in `taskcluster.AwsProvisioner`

--- a/lib/apis.js
+++ b/lib/apis.js
@@ -351,6 +351,20 @@ module.exports = {
         {
           "args": [
           ],
+          "description": "Utility method similar to `testAuthenticate`, but with the GET method,\nso it can be used with signed URLs (bewits).\n\nRather than using real credentials, this endpoint accepts requests with\nclientId `tester` and accessToken `no-secret`. That client's scopes are\n`['test:*', 'auth:create-client:test:*']`.  The call fails if the \n`test:authenticate-get` scope is not available.\n\nThe request is validated, with any certificate, authorizedScopes, etc.\napplied, and the resulting scopes are checked, just like any API call.\nOn success, the response contains the clientId and scopes as seen by\nthe API method.\n\nThis method may later be extended to allow specification of client and\nrequired scopes via query arguments.",
+          "method": "get",
+          "name": "testAuthenticateGet",
+          "output": "http://schemas.taskcluster.net/auth/v1/test-authenticate-response.json#",
+          "query": [
+          ],
+          "route": "/test-authenticate-get/",
+          "stability": "experimental",
+          "title": "Test Authentication (GET)",
+          "type": "function"
+        },
+        {
+          "args": [
+          ],
           "description": "Documented later...\n\n**Warning** this api end-point is **not stable**.",
           "method": "get",
           "name": "ping",
@@ -841,6 +855,8 @@ module.exports = {
           "method": "get",
           "name": "listHookGroups",
           "output": "http://schemas.taskcluster.net/hooks/v1/list-hook-groups-response.json",
+          "query": [
+          ],
           "route": "/hooks",
           "stability": "experimental",
           "title": "List hook groups",
@@ -854,6 +870,8 @@ module.exports = {
           "method": "get",
           "name": "listHooks",
           "output": "http://schemas.taskcluster.net/hooks/v1/list-hooks-response.json",
+          "query": [
+          ],
           "route": "/hooks/<hookGroupId>",
           "stability": "experimental",
           "title": "List hooks in a given group",
@@ -868,6 +886,8 @@ module.exports = {
           "method": "get",
           "name": "hook",
           "output": "http://schemas.taskcluster.net/hooks/v1/hook-definition.json",
+          "query": [
+          ],
           "route": "/hooks/<hookGroupId>/<hookId>",
           "stability": "experimental",
           "title": "Get hook definition",
@@ -882,6 +902,8 @@ module.exports = {
           "method": "get",
           "name": "getHookStatus",
           "output": "http://schemas.taskcluster.net/hooks/v1/hook-status.json",
+          "query": [
+          ],
           "route": "/hooks/<hookGroupId>/<hookId>/status",
           "stability": "experimental",
           "title": "Get hook status",
@@ -896,6 +918,8 @@ module.exports = {
           "method": "get",
           "name": "getHookSchedule",
           "output": "http://schemas.taskcluster.net/hooks/v1/hook-schedule.json",
+          "query": [
+          ],
           "route": "/hooks/<hookGroupId>/<hookId>/schedule",
           "stability": "deprecated",
           "title": "Get hook schedule",
@@ -911,6 +935,8 @@ module.exports = {
           "method": "put",
           "name": "createHook",
           "output": "http://schemas.taskcluster.net/hooks/v1/hook-definition.json",
+          "query": [
+          ],
           "route": "/hooks/<hookGroupId>/<hookId>",
           "scopes": [
             [
@@ -932,6 +958,8 @@ module.exports = {
           "method": "post",
           "name": "updateHook",
           "output": "http://schemas.taskcluster.net/hooks/v1/hook-definition.json",
+          "query": [
+          ],
           "route": "/hooks/<hookGroupId>/<hookId>",
           "scopes": [
             [
@@ -951,6 +979,8 @@ module.exports = {
           "description": "This endpoint will remove a hook definition.",
           "method": "delete",
           "name": "removeHook",
+          "query": [
+          ],
           "route": "/hooks/<hookGroupId>/<hookId>",
           "scopes": [
             [

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -361,9 +361,21 @@ suite('client requests/responses', function() {
     assert(record.baseUrl, "Error in record.baseUrl");
   });
 
+  let assertBewitUrl = function(url, expected) {
+    url = url.replace(/bewit=[^&]*/, "bewit=XXX");
+    assert.equal(url, expected);
+  };
+
+  // note that the signatures for buildSignedUrl are checked in creds_test.js
+
   test('BuildUrl', async () => {
     let url = client.buildUrl(client.get);
     assert.equal(url, 'https://fake.taskcluster.net/v1/get-test');
+  });
+
+  test('BuildSignedUrl', async () => {
+    let url = client.buildSignedUrl(client.get);
+    assertBewitUrl(url, "https://fake.taskcluster.net/v1/get-test?bewit=XXX");
   });
 
   test('BuildUrl with parameter', async () => {
@@ -371,9 +383,20 @@ suite('client requests/responses', function() {
     assert.equal(url, 'https://fake.taskcluster.net/v1/url-param/test/list');
   });
 
+  test('BuildSignedUrl with parameter', async () => {
+    let url = client.buildSignedUrl(client.param, 'test');
+    assertBewitUrl(url, "https://fake.taskcluster.net/v1/url-param/test/list?bewit=XXX");
+  });
+
   test('BuildUrl with two parameters', async () => {
     let url = client.buildUrl(client.param2, 'test', 'te/st');
     assert.equal(url, 'https://fake.taskcluster.net/v1/url-param2/test/te%2Fst/list');
+  });
+
+  test('BuildSignedUrl with two parameters', async () => {
+    let url = client.buildSignedUrl(client.param2, 'test', 'te/st');
+    assertBewitUrl(url,
+      'https://fake.taskcluster.net/v1/url-param2/test/te%2Fst/list?bewit=XXX');
   });
 
   test('BuildUrl with missing parameter', async () => {
@@ -385,14 +408,33 @@ suite('client requests/responses', function() {
     assert(false);
   });
 
+  test('BuildSignedUrl with missing parameter', async () => {
+    try {
+      client.buildSignedUrl(client.param2, 'te/st');
+    } catch (err) {
+      return;
+    }
+    assert(false);
+  });
+
   test('BuildUrl with query-string', async () => {
     let url = client.buildUrl(client.query, {option: 2});
     assert.equal(url, 'https://fake.taskcluster.net/v1/query/test?option=2');
   });
 
+  test('BuildSignedUrl with query-string', async () => {
+    let url = client.buildSignedUrl(client.query, {option: 2});
+    assertBewitUrl(url, 'https://fake.taskcluster.net/v1/query/test?option=2&bewit=XXX');
+  });
+
   test('BuildUrl with empty query-string', async () => {
     let url = client.buildUrl(client.query, {});
     assert.equal(url, 'https://fake.taskcluster.net/v1/query/test');
+  });
+
+  test('BuildSignedUrl with query-string', async () => {
+    let url = client.buildSignedUrl(client.query, {});
+    assertBewitUrl(url, 'https://fake.taskcluster.net/v1/query/test?bewit=XXX');
   });
 
   test('BuildUrl with query-string (wrong key)', async () => {
@@ -404,9 +446,24 @@ suite('client requests/responses', function() {
     assert(false);
   });
 
+  test('BuildSignedUrl with query-string (wrong key)', async () => {
+    try {
+      client.buildSignedUrl(client.query, {wrongKey: 2});
+    } catch (err) {
+      return;
+    }
+    assert(false);
+  });
+
   test('BuildUrl with param and query-string', async () => {
     let url = client.buildUrl(client.paramQuery, 'test', {option: 2});
     assert.equal(url, 'https://fake.taskcluster.net/v1/param-query/test?option=2');
+  });
+
+  test('BuildSignedUrl with param and query-string', async () => {
+    let url = client.buildSignedUrl(client.paramQuery, 'test', {option: 2});
+    assertBewitUrl(url,
+      'https://fake.taskcluster.net/v1/param-query/test?option=2&bewit=XXX');
   });
 
   test('BuildUrl with param and no query (when supported)', async () => {
@@ -414,9 +471,29 @@ suite('client requests/responses', function() {
     assert.equal(url, 'https://fake.taskcluster.net/v1/param-query/test?option=34');
   });
 
+  test('BuildSignedUrl with param and no query (when supported)', async () => {
+    let url = client.buildSignedUrl(client.paramQuery, 'test', {option: 34});
+    assertBewitUrl(url,
+      'https://fake.taskcluster.net/v1/param-query/test?option=34&bewit=XXX');
+  });
+
   test('BuildUrl with param and empty query', async () => {
     let url = client.buildUrl(client.paramQuery, 'test', {});
     assert.equal(url, 'https://fake.taskcluster.net/v1/param-query/test');
+  });
+
+  test('BuildSignedUrl with param and empty query', async () => {
+    let url = client.buildSignedUrl(client.paramQuery, 'test', {});
+    assertBewitUrl(url, 'https://fake.taskcluster.net/v1/param-query/test?bewit=XXX');
+  });
+
+  test('BuildUrl with missing parameter, but query options', async () => {
+    try {
+      client.buildUrl(client.paramQuery, {option: 2});
+    } catch (err) {
+      return;
+    }
+    assert(false);
   });
 
   test('BuildUrl with missing parameter, but query options', async () => {
@@ -436,4 +513,14 @@ suite('client requests/responses', function() {
     }
     assert(false);
   });
+
+  test('buildSignedUrl for missing method', async () => {
+    try {
+      client.buildSignedUrl('test');
+    } catch (err) {
+      return;
+    }
+    assert(false);
+  });
+
 });


### PR DESCRIPTION
I moved some of the buildSignedUrl calls out to `client_test.js` since they were really just testing well-formedness of the resulting URL.  That left just the calls verifying the bewit format in `creds_test.js`.