### PR TITLE
Update to include triggerHook from hooks api

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ var hooks = new taskcluster.Hooks(options);
  * `hooks.createHook(hookGroupId, hookId, payload) : result`
  * `hooks.updateHook(hookGroupId, hookId, payload) : result`
  * `hooks.removeHook(hookGroupId, hookId) : void`
+ * `hooks.triggerHook(hookGroupId, hookId, payload) : result`
 
 ### Methods in `taskcluster.Index`
 ```js

--- a/lib/apis.js
+++ b/lib/apis.js
@@ -1052,6 +1052,28 @@ module.exports = {
           "stability": "experimental",
           "title": "Delete a hook",
           "type": "function"
+        },
+        {
+          "args": [
+            "hookGroupId",
+            "hookId"
+          ],
+          "description": "This endpoint will trigger the creation of a task from a hook definition.",
+          "input": "http://schemas.taskcluster.net/hooks/v1/trigger-payload.json",
+          "method": "post",
+          "name": "triggerHook",
+          "output": "http://schemas.taskcluster.net/hooks/v1/task-status.json",
+          "query": [
+          ],
+          "route": "/hooks/<hookGroupId>/<hookId>/trigger",
+          "scopes": [
+            [
+              "hooks:trigger-hook:<hookGroupId>/<hookId>"
+            ]
+          ],
+          "stability": "experimental",
+          "title": "Trigger a hook",
+          "type": "function"
         }
       ],
       "title": "Hooks API Documentation",


### PR DESCRIPTION
This patch updates the taskcluster-client to support the triggerHook api call. This will be used in taskcluster-tools to trigger hooks through the tools page.