### PR TITLE
include the HTTP method in the "Calling: " log line

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -277,7 +277,7 @@ exports.createClient = function(reference, name) {
       var retryRequest = function() {
         // Send request
         var sendRequest = function() {
-          debug("Calling: %s, retry: %s", entry.name, attempts - 1);
+          debug("Calling: %s %s, retry: %s", entry.method.toUpperCase(), entry.name, attempts - 1);
           // Make request and handle response or error
           return makeRequest(
             that,


### PR DESCRIPTION
in bug 1310561, the error message we're getting is looking like somehow the PUT to /task/:taskId is actually being run as a GET based on the error messages.  I think this extra debugging is generally useful, but I would like to include this fairly soon for debugging purposes.
