### PR TITLE
[RFC] Paramaterize base domain to allow multiple independent deployments.

### DIFF
--- a/lib/apis.js
+++ b/lib/apis.js
@@ -2,7 +2,8 @@ module.exports = {
   "Auth": {
     "reference": {
       "$schema": "http://schemas.taskcluster.net/base/v1/api-reference.json#",
-      "baseUrl": "https://auth.taskcluster.net/v1",
+      "subdomain": "auth",
+      "basePath": "/v1",
       "description": "Authentication related API end-points for TaskCluster and related\nservices. These API end-points are of interest if you wish to:\n  * Authenticate request signed with TaskCluster credentials,\n  * Manage clients and roles,\n  * Inspect or audit clients and roles,\n  * Gain access to various services guarded by this API.\n\n### Clients\nThe authentication service manages _clients_, at a high-level each client\nconsists of a `clientId`, an `accessToken`, scopes, and some metadata.\nThe `clientId` and `accessToken` can be used for authentication when\ncalling TaskCluster APIs.\n\nThe client's scopes control the client's access to TaskCluster resources.\nThe scopes are *expanded* by substituting roles, as defined below.\n\n### Roles\nA _role_ consists of a `roleId`, a set of scopes and a description.\nEach role constitutes a simple _expansion rule_ that says if you have\nthe scope: `assume:<roleId>` you get the set of scopes the role has.\nThink of the `assume:<roleId>` as a scope that allows a client to assume\na role.\n\nAs in scopes the `*` kleene star also have special meaning if it is\nlocated at the end of a `roleId`. If you have a role with the following\n`roleId`: `my-prefix*`, then any client which has a scope staring with\n`assume:my-prefix` will be allowed to assume the role.\n\n### Guarded Services\nThe authentication service also has API end-points for delegating access\nto some guarded service such as AWS S3, or Azure Table Storage.\nGenerally, we add API end-points to this server when we wish to use\nTaskCluster credentials to grant access to a third-party service used\nby many TaskCluster components.",
       "entries": [
         {

--- a/lib/apis.js
+++ b/lib/apis.js
@@ -1758,7 +1758,8 @@ module.exports = {
   "Queue": {
     "reference": {
       "$schema": "http://schemas.taskcluster.net/base/v1/api-reference.json#",
-      "baseUrl": "https://queue.taskcluster.net/v1",
+      "basePath": "/v1",
+      "subdomain": "queue",
       "description": "The queue, typically available at `queue.taskcluster.net`, is responsible\nfor accepting tasks and track their state as they are executed by\nworkers. In order ensure they are eventually resolved.\n\nThis document describes the API end-points offered by the queue. These \nend-points targets the following audience:\n * Schedulers, who create tasks to be executed,\n * Workers, who execute tasks, and\n * Tools, that wants to inspect the state of a task.",
       "entries": [
         {

--- a/lib/client.js
+++ b/lib/client.js
@@ -143,8 +143,13 @@ exports.createClient = function(reference, name) {
   var Client = function(options) {
     this._options = _.defaults({}, options || {}, {
       baseUrl:          reference.baseUrl        || '',
+      baseDomain:       'taskcluster.net',
       exchangePrefix:   reference.exchangePrefix || ''
     }, _defaultOptions);
+
+    if (!this._options.baseUrl) {
+      this._options.baseUrl = "https://" + reference.subdomain + "." + this._options.baseDomain + reference.basePath;
+    }
 
     if (this._options.stats) {
       throw new Error("options.stats is now deprecated! Use options.monitor instead.");


### PR DESCRIPTION
I'm experimenting with deploying an independent installation of taskcluster. Given that the client is coded against a particular version of all the APIs, I don't think it makes for a user to have to specify the version (i.e. the path part of the URL). Similarly, I don't think think it makes sense for the user to specify alternative mappings of subdomains to services.

This is a sketch of switching the client to only require specifying the top-level domain (i.e. `taskcluster.net`), rather than the full URL for each service.

See [here](https://github.com/taskcluster/taskcluster-tools/pull/169) for a start of switching taskcluster-tools to using this parametrization.