### PR TITLE
taskcluster-pulse integration

### DIFF
--- a/lib/pulselistener.js
+++ b/lib/pulselistener.js
@@ -143,15 +143,18 @@ PulseConnection.prototype.connect = function() {
     if (this.isTaskclusterPulse) {
       // Request new credentials every time we create a connection in case they
       // have been rotated.
-      var pulseCredentials = this._pulse.namespace(
-        this.namespace, {contact: this._contact});
-      this._connectionString = buildPulseConnectionString({
-        username: pulseCredentials.username,
-        password: pulseCredentials.password,
-        hostname: this.hostname,
-      });
+      var getCredentials = this._pulse.namespace(
+        this.namespace, {contact: this._contact}).then(function(credentials) {
+          that._connectionString = buildPulseConnectionString({
+            username: credentials.username,
+            password: credentials.password,
+            hostname: that.hostname,
+          });
+        });
     }
-    retryConnect(this._connectionString, 7).then(function(conn) {
+    Promise.resolve(getCredentials).then(function() {
+      return retryConnect(that._connectionString, 7);
+    }).then(function(conn) {
       // Save reference to the connection
       that._conn = conn;
 

--- a/lib/pulselistener.js
+++ b/lib/pulselistener.js
@@ -7,6 +7,7 @@ var _         = require('lodash');
 var assert    = require('assert');
 var slugid    = require('slugid');
 var URL       = require('url');
+var tc        = require('./client.js');
 
 /**
  * Build Pulse ConnectionString, from options on the form:
@@ -65,12 +66,20 @@ var PulseConnection = function(options) {
     namespace:          options.username || ''
   });
 
-  if (!options.connectionString) {
-    options.connectionString = buildPulseConnectionString(options);
-  } else {
+  this.isTaskclusterPulse = false;
+  if (options.connectionString) {
     assert(!options.username, "Can't take `username` along with `connectionString`");
     assert(!options.password, "Can't take `password` along with `connectionString`");
     assert(!options.hostname, "Can't take `hostname` along with `connectionString`");
+  } else if (options.username && options.password) {
+    // TODO: Deprecated warnings.
+    options.connectionString = buildPulseConnectionString(options);
+  } else {
+    assert(!options.namespace,
+      "Must provide `namespace` when Pulse credentials are managed by taskcluster-pulse");
+    // It should already be falsy at this point, but just to make it explicit.
+    this._pulse = new tc.Pulse();
+    this.isTaskclusterPulse = true;
   }
 
   // If namespace was not explicitly set infer it from connection string...
@@ -79,6 +88,7 @@ var PulseConnection = function(options) {
     options.namespace = parsed.auth.split(':')[0];
   }
 
+  this.hostname = options.hostname;
   this.namespace = options.namespace;
   this._connectionString = options.connectionString;
 
@@ -112,6 +122,15 @@ PulseConnection.prototype.connect = function() {
   // Connect if we're not already doing this
   if (!this._connecting) {
     this._connecting = true;
+    if (this.isTaskclusterPulse) {
+      // TODO: provide contact to tc-pulse.
+      var pulseCredentials = this._pulse.namespace(this.namespace);
+      this._connectionString = buildPulseConnectionString({
+        username: pulseCredentials.username,
+        password: pulseCredentials.password,
+        hostname: this.hostname,
+      });
+    }
     retryConnect(this._connectionString, 7).then(function(conn) {
       // Save reference to the connection
       that._conn = conn;
@@ -267,8 +286,10 @@ PulseListener.prototype.connect = function() {
   var exclusive = !this._options.queueName;
   // Construct queue name
   this._queueName = [
-    'queue',                      // Required by pulse security model
-    this._connection.namespace,   // Required by pulse security model
+    // Prefix required by pulse security model
+    this._connection.isTaskclusterPulse ? 'taskcluster/queues' : 'queue',
+    this._connection.namespace,
+    // Custom suffix
     this._options.queueName || 'exclusive/' + slugid.v4()
   ].join('/')
 

--- a/lib/pulselistener.js
+++ b/lib/pulselistener.js
@@ -93,7 +93,7 @@ var PulseConnection = function(options) {
     // TODO: Deprecated warnings.
     options.connectionString = buildPulseConnectionString(options);
   } else {
-    assert(!options.contact,
+    assert(options.contact,
       "Must provide `contact` when Pulse credentials are managed by taskcluster-pulse");
     this._contact = options.contact;
     this._pulse = new tc.Pulse();

--- a/lib/pulselistener.js
+++ b/lib/pulselistener.js
@@ -52,12 +52,29 @@ var retryConnect = function(connectionString, retries) {
  * {
  *   namespace:         // Namespace to prefix queues/exchanges (optional)
  *                      // defaults to `username` if given otherwise ""
- *   username:          // Username to connect with (and namespace if not given)
- *   password:          // Password to connect with
- *   hostname:          // Hostname to connect to using username/password
- *                      // defaults to pulse.mozilla.org
- *   connectionString:  // connectionString cannot be used with username,
- *                      // password and/or hostname.
+ *   hostname:          // Hostname to connect to (optional, defaults to
+ *                      // pulse.mozilla.org)
+ *   // Contact info sent to taskcluster-pulse when requesting credentials
+ *   // (required when credentials are managed by taskcluster-pulse)
+ *   contact: {         // One of:
+ *     method: 'irc',
+ *     payload: {
+ *       // Specify one of channel or user.
+ *       channel:       // Including the leading '#', e.g. '#some-channel'
+ *       user:
+ *     }
+ *   }, {               // or
+ *     method: 'email',
+ *     payload: {
+ *       address:
+ *     }
+ *   }
+ *   // When provided, username/password will be used to connect to Pulse.
+ *   // Newer code shouldn't supply them, but use taskcluster-pulse instead.
+ *   username:          // Pulse username (deprecated)
+ *   password:          // Pulse password (deprecated)
+ *   connectionString:  // connectionString cannot be used with contact,
+ *                      // username/password, and/or hostname.
  * }
  */
 var PulseConnection = function(options) {
@@ -71,13 +88,14 @@ var PulseConnection = function(options) {
     assert(!options.username, "Can't take `username` along with `connectionString`");
     assert(!options.password, "Can't take `password` along with `connectionString`");
     assert(!options.hostname, "Can't take `hostname` along with `connectionString`");
+    assert(!options.contact, "Can't take `contact` along with `connectionString`");
   } else if (options.username && options.password) {
     // TODO: Deprecated warnings.
     options.connectionString = buildPulseConnectionString(options);
   } else {
-    assert(!options.namespace,
-      "Must provide `namespace` when Pulse credentials are managed by taskcluster-pulse");
-    // It should already be falsy at this point, but just to make it explicit.
+    assert(!options.contact,
+      "Must provide `contact` when Pulse credentials are managed by taskcluster-pulse");
+    this._contact = options.contact;
     this._pulse = new tc.Pulse();
     this.isTaskclusterPulse = true;
   }
@@ -123,8 +141,10 @@ PulseConnection.prototype.connect = function() {
   if (!this._connecting) {
     this._connecting = true;
     if (this.isTaskclusterPulse) {
-      // TODO: provide contact to tc-pulse.
-      var pulseCredentials = this._pulse.namespace(this.namespace);
+      // Request new credentials every time we create a connection in case they
+      // have been rotated.
+      var pulseCredentials = this._pulse.namespace(
+        this.namespace, {contact: this._contact});
       this._connectionString = buildPulseConnectionString({
         username: pulseCredentials.username,
         password: pulseCredentials.password,
@@ -179,12 +199,29 @@ exports.PulseConnection = PulseConnection;
  *   credentials: {
  *     namespace:         // Namespace to prefix queues/exchanges (optional)
  *                        // defaults to `username` if given otherwise ""
- *     username:          // Pulse username
- *     password:          // Pulse password
- *     hostname:          // Hostname to connect to using username/password
- *                        // defaults to pulse.mozilla.org
- *     connectionString:  // connectionString overwrites username/password and
- *                        // hostname (if given)
+ *     connectionString:  // If given, overwrites all the following connection
+ *                        // options (hostname, contact, and username/password)
+ *     hostname:          // Hostname to connect to (optional, defaults to
+ *                        // pulse.mozilla.org)
+ *     // Contact info sent to taskcluster-pulse when requesting credentials
+ *     // (required when credentials are managed by taskcluster-pulse)
+ *     contact: {         // One of:
+ *       method: 'irc',
+ *       payload: {
+ *         // Specify one of channel or user.
+ *         channel:       // Including the leading '#', e.g. '#some-channel'
+ *         user:
+ *       }
+ *     }, {               // or
+ *       method: 'email',
+ *       payload: {
+ *         address:
+ *       }
+ *     }
+ *     // When provided, username/password will be used to connect to Pulse.
+ *     // Newer code shouldn't supply them, but use taskcluster-pulse instead.
+ *     username:          // Pulse username (deprecated)
+ *     password:          // Pulse password (deprecated)
  *   }
  *   maxLength:           // Maximum queue size, undefined for none
  * }

--- a/lib/pulselistener.js
+++ b/lib/pulselistener.js
@@ -83,7 +83,7 @@ var PulseConnection = function(options) {
     namespace:          options.username || ''
   });
 
-  this.isTaskclusterPulse = false;
+  this._isTaskclusterPulse = false;
   if (options.connectionString) {
     assert(!options.username, "Can't take `username` along with `connectionString`");
     assert(!options.password, "Can't take `password` along with `connectionString`");
@@ -96,8 +96,7 @@ var PulseConnection = function(options) {
     assert(options.contact,
       "Must provide `contact` when Pulse credentials are managed by taskcluster-pulse");
     this._contact = options.contact;
-    this._pulse = new tc.Pulse();
-    this.isTaskclusterPulse = true;
+    this._isTaskclusterPulse = true;
   }
 
   // If namespace was not explicitly set infer it from connection string...
@@ -140,10 +139,12 @@ PulseConnection.prototype.connect = function() {
   // Connect if we're not already doing this
   if (!this._connecting) {
     this._connecting = true;
-    if (this.isTaskclusterPulse) {
+    var getCredentials = null;
+    if (this._isTaskclusterPulse) {
       // Request new credentials every time we create a connection in case they
       // have been rotated.
-      var getCredentials = this._pulse.namespace(
+      var tcPulse = new tc.Pulse()
+      getCredentials = tcPulse.namespace(
         this.namespace, {contact: this._contact}).then(function(credentials) {
           that._connectionString = buildPulseConnectionString({
             username: credentials.username,
@@ -198,6 +199,7 @@ exports.PulseConnection = PulseConnection;
  * options: {
  *   prefetch:            // Max number of messages unacknowledged to hold
  *   queueName:           // Queue name, defaults to exclusive auto-delete queue
+ *   queuePrefix:         // TODO
  *   connection:          // PulseConnection object (or credentials)
  *   credentials: {
  *     namespace:         // Namespace to prefix queues/exchanges (optional)
@@ -242,6 +244,7 @@ var PulseListener = function(options) {
   this._options = _.defaults(options, {
     prefetch:               5,
     queueName:              undefined,
+    queuePrefix:            undefined,
     maxLength:              undefined
   });
   // Ensure that we have connection object
@@ -253,6 +256,12 @@ var PulseListener = function(options) {
     this._connection.on('error', function(err) {
       that.emit('error', err);
     });
+  }
+  // Set the default queue prefix based on whether taskcluster-pulse is used.
+  if (!this._options.queuePrefix) {
+    this._options.queuePrefix =
+      (options.credentials.connectionString || options.credentials.username) ?
+      'queue' : 'taskcluster/queues';
   }
 };
 
@@ -326,8 +335,8 @@ PulseListener.prototype.connect = function() {
   var exclusive = !this._options.queueName;
   // Construct queue name
   this._queueName = [
-    // Prefix required by pulse security model
-    this._connection.isTaskclusterPulse ? 'taskcluster/queues' : 'queue',
+    // Prefix and namespace required by Pulse security model
+    this._options.queuePrefix,
     this._connection.namespace,
     // Custom suffix
     this._options.queueName || 'exclusive/' + slugid.v4()

--- a/lib/pulselistener.js
+++ b/lib/pulselistener.js
@@ -173,6 +173,7 @@ PulseConnection.prototype.connect = function() {
     if (this._isTaskclusterPulse) {
       // Request new credentials every time we create a connection in case they
       // have been rotated.
+      // TODO: Only request new credentials when the expiration is reached.
       var tcPulse = new tc.Pulse({
         credentials: this._credentials || undefined,
         baseUrl: this._baseUrl || undefined

--- a/lib/pulselistener.js
+++ b/lib/pulselistener.js
@@ -34,6 +34,15 @@ var buildPulseConnectionString = function(options) {
   ].join('');
 };
 
+var getDefaultContact = function() {
+  return {
+    method: 'email',
+    payload: {
+      address: process.env.OWNER_EMAIL
+    }
+  };
+}
+
 /** Connect to AMQP server while retrying connection establishment */
 var retryConnect = function(connectionString, retries) {
   return amqplib.connect(connectionString, {
@@ -50,12 +59,29 @@ var retryConnect = function(connectionString, retries) {
 /**
  * Create PulseConnection from `options` on the form:
  * {
- *   namespace:         // Namespace to prefix queues/exchanges (optional)
- *                      // defaults to `username` if given otherwise ""
+ *   namespace:         // Namespace to prefix queues/exchanges (optional
+ *                      // when using connectionString or username/password,
+ *                      // defaults to `username` if given otherwise "";
+ *                      // required when using taskcluster-pulse)
+ *   // There are 3 exclusive ways to configure Pulse credentials. Please only
+ *   // use one of them - if properties belonging to different groups are
+ *   // provided at the same time, exceptions will be raised.
+ *   // 1. connectionString
+ *   connectionString:  // An AQMP URI containing the protocol, username,
+ *                      // password, hostname, etc. to be used directly.
+ *   // 2. Pulse username and password (deprecated)
+ *   username:          // Pulse username
+ *   password:          // Pulse password
  *   hostname:          // Hostname to connect to (optional, defaults to
  *                      // pulse.mozilla.org)
+ *   // 3. Taskcluster-Pulse (recommended; when only namespace is provided,
+ *   // this method will be used)
+ *   credentials:       // *Taskcluster* credentials (optional, defaults to
+ *                      // the TC credentials from env)
+ *   baseUrl:           // Base URL of taskcluster-pulse (optional, defaults
+ *                      // to https://pulse.taskcluster.net/v1)
  *   // Contact info sent to taskcluster-pulse when requesting credentials
- *   // (required when credentials are managed by taskcluster-pulse)
+ *   // (optional, defaults to process.env.OWNER_EMAIL)
  *   contact: {         // One of:
  *     method: 'irc',
  *     payload: {
@@ -69,12 +95,6 @@ var retryConnect = function(connectionString, retries) {
  *       address:
  *     }
  *   }
- *   // When provided, username/password will be used to connect to Pulse.
- *   // Newer code shouldn't supply them, but use taskcluster-pulse instead.
- *   username:          // Pulse username (deprecated)
- *   password:          // Pulse password (deprecated)
- *   connectionString:  // connectionString cannot be used with contact,
- *                      // username/password, and/or hostname.
  * }
  */
 var PulseConnection = function(options) {
@@ -89,13 +109,25 @@ var PulseConnection = function(options) {
     assert(!options.password, "Can't take `password` along with `connectionString`");
     assert(!options.hostname, "Can't take `hostname` along with `connectionString`");
     assert(!options.contact, "Can't take `contact` along with `connectionString`");
+    assert(!options.baseUrl, "Can't take `baseUrl` along with `connectionString`");
+    assert(!options.credentials, "Can't take `credentials` along with `connectionString`");
+    this._connectionString = options.connectionString;
   } else if (options.username && options.password) {
     // TODO: Deprecated warnings.
-    options.connectionString = buildPulseConnectionString(options);
+    assert(!options.contact,
+      "Can't take `contact` along with `username` and `password`");
+    assert(!options.baseUrl,
+      "Can't take `baseUrl` along with `username` and `password`");
+    assert(!options.credentials,
+      "Can't take `credentials` along with `username` and `password`");
+    this._connectionString = buildPulseConnectionString(options);
   } else {
-    assert(options.contact,
-      "Must provide `contact` when Pulse credentials are managed by taskcluster-pulse");
-    this._contact = options.contact;
+    // Taskcluster-pulse
+    assert(options.namespace, "Must provide `namespace` when using taskcluster-pulse");
+    assert(!options.hostname, "Can't take `hostname` when using taskcluster-pulse");
+    this._contact = options.contact || getDefaultContact();
+    this._credentials = options.credentials;
+    this._baseUrl = options.baseUrl;
     this._isTaskclusterPulse = true;
   }
 
@@ -105,9 +137,7 @@ var PulseConnection = function(options) {
     options.namespace = parsed.auth.split(':')[0];
   }
 
-  this.hostname = options.hostname;
   this.namespace = options.namespace;
-  this._connectionString = options.connectionString;
 
   // Private properties
   this._conn              = null;
@@ -139,21 +169,25 @@ PulseConnection.prototype.connect = function() {
   // Connect if we're not already doing this
   if (!this._connecting) {
     this._connecting = true;
-    var getCredentials = null;
+    var getPulseCredentials = null;
     if (this._isTaskclusterPulse) {
       // Request new credentials every time we create a connection in case they
       // have been rotated.
-      var tcPulse = new tc.Pulse()
-      getCredentials = tcPulse.namespace(
-        this.namespace, {contact: this._contact}).then(function(credentials) {
-          that._connectionString = buildPulseConnectionString({
-            username: credentials.username,
-            password: credentials.password,
-            hostname: that.hostname,
-          });
+      var tcPulse = new tc.Pulse({
+        credentials: this._credentials || undefined,
+        baseUrl: this._baseUrl || undefined
+      });
+      getPulseCredentials = tcPulse.namespace(
+        this.namespace, {contact: this._contact}
+      ).then(function(pulseCredentials) {
+        that._connectionString = buildPulseConnectionString({
+          username: pulseCredentials.username,
+          password: pulseCredentials.password,
+          hostname: that.hostname,
         });
+      });
     }
-    Promise.resolve(getCredentials).then(function() {
+    Promise.resolve(getPulseCredentials).then(function() {
       return retryConnect(that._connectionString, 7);
     }).then(function(conn) {
       // Save reference to the connection
@@ -199,17 +233,34 @@ exports.PulseConnection = PulseConnection;
  * options: {
  *   prefetch:            // Max number of messages unacknowledged to hold
  *   queueName:           // Queue name, defaults to exclusive auto-delete queue
- *   queuePrefix:         // TODO
+ *   queuePrefix:         // Prefix of queue paths (optional, defaults to
+ *                        // 'taskcluster/queues' when using taskcluster-pulse,
+ *                        // 'queue' otherwise)
  *   connection:          // PulseConnection object (or credentials)
  *   credentials: {
- *     namespace:         // Namespace to prefix queues/exchanges (optional)
- *                        // defaults to `username` if given otherwise ""
- *     connectionString:  // If given, overwrites all the following connection
- *                        // options (hostname, contact, and username/password)
+ *     namespace:         // Namespace to prefix queues/exchanges (optional
+ *                        // when using connectionString or username/password,
+ *                        // defaults to `username` if given otherwise "";
+ *                        // required when using taskcluster-pulse)
+ *     // There are 3 exclusive ways to configure Pulse credentials. Please only
+ *     // use one of them - if properties belonging to different groups are
+ *     // provided at the same time, exceptions will be raised.
+ *     // 1. connectionString
+ *     connectionString:  // An AQMP URI containing the protocol, username,
+ *                        // password, hostname, etc. to be used directly.
+ *     // 2. Pulse username and password (deprecated)
+ *     username:          // Pulse username
+ *     password:          // Pulse password
  *     hostname:          // Hostname to connect to (optional, defaults to
  *                        // pulse.mozilla.org)
+ *     // 3. Taskcluster-Pulse (recommended; when only namespace is provided,
+ *     // this method will be used)
+ *     credentials:       // *Taskcluster* credentials (optional, defaults to
+ *                        // the TC credentials from env)
+ *     baseUrl:           // Base URL of taskcluster-pulse (optional, defaults
+ *                        // to https://pulse.taskcluster.net/v1)
  *     // Contact info sent to taskcluster-pulse when requesting credentials
- *     // (required when credentials are managed by taskcluster-pulse)
+ *     // (optional, defaults to process.env.OWNER_EMAIL)
  *     contact: {         // One of:
  *       method: 'irc',
  *       payload: {
@@ -223,10 +274,6 @@ exports.PulseConnection = PulseConnection;
  *         address:
  *       }
  *     }
- *     // When provided, username/password will be used to connect to Pulse.
- *     // Newer code shouldn't supply them, but use taskcluster-pulse instead.
- *     username:          // Pulse username (deprecated)
- *     password:          // Pulse password (deprecated)
  *   }
  *   maxLength:           // Maximum queue size, undefined for none
  * }

--- a/lib/pulselistener.js
+++ b/lib/pulselistener.js
@@ -180,11 +180,7 @@ PulseConnection.prototype.connect = function() {
       getPulseCredentials = tcPulse.namespace(
         this.namespace, {contact: this._contact}
       ).then(function(pulseCredentials) {
-        that._connectionString = buildPulseConnectionString({
-          username: pulseCredentials.username,
-          password: pulseCredentials.password,
-          hostname: that.hostname,
-        });
+        that._connectionString = pulseCredentials.connectionString;
       });
     }
     Promise.resolve(getPulseCredentials).then(function() {

--- a/test/pulselistener_test.js
+++ b/test/pulselistener_test.js
@@ -103,10 +103,11 @@ suite('PulseListener', function() {
         nock('https://pulse.taskcluster.net')
           .post('/v1/namespace/' + creds.namespace)
           .reply(200, {
-            username: cfg.pulse.username,
-            password: cfg.pulse.password,
             connectionString: connectionString,
-            expiration: '' // TODO not used for now
+            expiration: '3000-12-31T00:00:00.000Z',
+            // The following two fields are not used here but listed for completeness.
+            namespace: creds.namespace,
+            contact: contact
           });
       }
       var listener = new taskcluster.PulseListener({credentials: creds});

--- a/test/pulselistener_test.js
+++ b/test/pulselistener_test.js
@@ -103,10 +103,10 @@ suite('PulseListener', function() {
         nock('https://pulse.taskcluster.net')
           .post('/v1/namespace/' + creds.namespace)
           .reply(200, {
-            namespace: creds.namespace,
             username: cfg.pulse.username,
             password: cfg.pulse.password,
-            contact: creds.contact
+            connectionString: connectionString,
+            expiration: '' // TODO not used for now
           });
       }
       var listener = new taskcluster.PulseListener({credentials: creds});


### PR DESCRIPTION
## Abstract

`PulseListener` is modified to support fetching Pulse credentials from [taskcluster-pulse](https://github.com/taskcluster/taskcluster-pulse/) with full backwards compatibility. Now, when creating a `PulseListener` instance, one can pass in the desired (Pulse) namespace and contact information (see the comments for detailed doc) instead of manually-configured Pulse username/password. `PulseListener` will then get Pulse credentials with necessary permissions from `taskcluster-pulse` before connecting, provided that the client has the correct scope. This process is transparent and the usage of constructed `PulseListener` instances is unaffected.

Also note that we will be using a new RabbitMQ name prefix (`taskcluster/{queues|exchanges}/...`, see L330 of `lib/pulselistener.js`). This change is worth some more discussion. I will drop by IRC on Monday to talk about it.

## Testing

Since only the code for establishing Pulse connection was changed, tests are focusing on this part too. Effectively, there are three supported methods to set up a connection now: 1. connection string; 2. Pulse username/password; 3. namespace and contact info (i.e. the new `taskcluster-pulse` way). We test the `bind` operation via these three methods individually.

When testing the `taskcluster-pulse` method, we mock its API endpoint using `nock` and return a fake response with Pulse username/password from `user-config.yml`, which was (and still is) precisely for testing purpose.

## Notes

* Currently `taskcluster-pulse` service is not working because of cert issues (taskcluster/taskcluster-pulse#60). Besides, it is managing a separate RabbitMQ cluster isolated from the production.
* I haven't done real integrating tests (partly of because of the issue above).
* Again, the top principle of this change is not to break any existing code.
* To migrate to `taskcluster-pulse`, all existing users of `PulseListener` must be modified to pass in the new constructor parameters. A TODO is to give deprecation warnings for hard-configured username/password.

Suggestions are more than welcome!