### PR TITLE
Fix the usage of nock in tests

### DIFF
--- a/test/client_test.js
+++ b/test/client_test.js
@@ -121,8 +121,8 @@ suite('client requests/responses', function() {
   };
 
   teardown(function() {
-    let pending = nock.pendingMocks();
-    assert.deepEqual(pending, []);
+    assert(nock.isDone());
+    nock.cleanAll();
   });
 
   let Fake = taskcluster.createClient(reference);

--- a/test/credinfo_test.js
+++ b/test/credinfo_test.js
@@ -4,12 +4,8 @@ suite('taskcluster.credentialInfo', function() {
   var nock            = require('nock');
 
   teardown(function() {
-    let pending = nock.pendingMocks();
-    assert.deepEqual(pending, []);
-  });
-
-  suiteTeardown(function() {
-    nock.restore();
+    assert(nock.isDone());
+    nock.cleanAll();
   });
 
   var setupNocks = function(options) {


### PR DESCRIPTION
### `nock.restore()` should not be called.

It restores all the overridden classes and methods, causing nock facilities to stop working in the following tests (potentially in other files), unless the undocumented API nock.activate() is called explicitly. On the other hand, this method does not clean up the interceptors, which is what we actually want. (If one calls  nock.activate() after nock.restore(), the previous interceptors will come into effect again.)

Use `nock.cleanAll()` instead and in the per-test teardown instead of the suite-wise teardown to ensure no mocks are leaked between tests.

This issue currently breaks the tests for #64 , since the `pulselistener_test.js` happens to run after the buggy `credinfo_test.js`. It wasn't noticed previously because all lexicographically larger tests don't use nock.

### `nock.isDone()` is the cleaner way to check remaining mocks.