### PR TITLE
Don't send auth headers if the endpoint doesn't use them

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -60,7 +60,7 @@ var _defaultOptions = {
 };
 
 /** Make a request for a Client instance */
-var makeRequest = function(client, method, url, payload, query) {
+var makeRequest = function(client, method, url, payload, query, noAuth) {
   // Add query to url if present
   if (query) {
     query = querystring.stringify(query);
@@ -85,8 +85,9 @@ var makeRequest = function(client, method, url, payload, query) {
     req.send(payload);
   }
 
-  // Authenticate, if credentials are provided
-  if (client._options.credentials &&
+  // Authenticate, if credentials are provided and the entry takes them
+  if (!noAuth &&
+      client._options.credentials &&
       client._options.credentials.clientId &&
       client._options.credentials.accessToken) {
     // Create hawk authentication header
@@ -287,7 +288,8 @@ exports.createClient = function(reference, name) {
             entry.method,
             url,
             payload,
-            query
+            query,
+            entry.noAuth
           ).end().then(function(res) {
             // If request was successful, accept the result
             debug("Success calling: %s, (%s retries)",


### PR DESCRIPTION
Perhaps if taskcluster/taskcluster-lib-api#59 makes sense, this can happen as well?

https://bugzilla.mozilla.org/show_bug.cgi?id=1352581