### PR TITLE
Support fake PulseConnection too

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,8 @@ It's inconvenient and error-prone to use real Pulse credentials in tests.  The
 PulseListener class supports a "fake" mode where it does not use any
 credentials, and messages are delivered by means of a `fakeMessage` method.
 
-To set up the listener, intialize it with `credentials: {fake: true}`. Once the
+To set up the listener, intialize it with `credentials: {fake: true}`, or with
+a PulseConnection created with `new PulseConnection({fake: true})`. Once the
 listener has been `resume()`d, call `listener.fakeMessage`.  Example:
 
 ```js

--- a/lib/pulselistener.js
+++ b/lib/pulselistener.js
@@ -57,6 +57,7 @@ var retryConnect = function(connectionString, retries) {
  *                      // defaults to pulse.mozilla.org
  *   connectionString:  // connectionString cannot be used with username,
  *                      // password and/or hostname.
+ *   fake:              // If true, do not connect to pulse (for tests)
  * }
  */
 var PulseConnection = function(options) {
@@ -64,6 +65,12 @@ var PulseConnection = function(options) {
   options = _.defaults({}, options, {
     namespace:          options.username || ''
   });
+
+  // a fake connection does notihng but signal its fake-ness to listeners
+  if (options.fake) {
+    this.fake = true;
+    return;
+  }
 
   if (!options.connectionString) {
     options.connectionString = buildPulseConnectionString(options);
@@ -196,7 +203,8 @@ var PulseListener = function(options) {
     maxLength:              undefined
   });
 
-  this._fake = options.credentials && options.credentials.fake;
+  this._fake = (options.credentials && options.credentials.fake) ||
+               (options.connection && options.connection.fake);
 
   // Ensure that we have connection object
   this._connection = options.connection || null;


### PR DESCRIPTION
So:
 * tc-index can be switched to use the existing fake PulseListener
 * tc-treeherder already does a good job of faking pulse
 * tc-github uses a PulseConnection, so we need fake support there, too