### PR TITLE
Support client.use(options)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ The `payload` parameter is always a JSON object as documented by the REST API
 documentation. The methods always returns a _promise_ for the response JSON
 object as documented in the REST API documentation.
 
+If you need to create a client similar to a existing client, but with some
+options changed, use `client.use(options)`:
+
+```js
+await queue.use({authorizedScopes: [..]}).createTask(..);
+```
+
 ## Listening for Events
 
 Many TaskCluster components publishes messages about current events to pulse.

--- a/lib/client.js
+++ b/lib/client.js
@@ -213,6 +213,11 @@ exports.createClient = function(reference, name) {
     }
   };
 
+  Client.prototype.use = function(optionsUpdates) {
+    var options = _.defaults({}, optionsUpdates, this._options);
+    return new Client(options);
+  };
+
   // For each function entry create a method on the Client class
   reference.entries.filter(function(entry) {
     return entry.type === 'function';

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -252,6 +252,15 @@ suite('client requests/responses', function() {
     });
   });
 
+  test('Use .use to set baseUrl (404)', async () => {
+    nock('https://fake-staging.taskcluster.net').get('/v1/get-test')
+      .reply(404, {code: 'NotFoundError'});
+    let client = new Fake().use({baseUrl: 'https://fake-staging.taskcluster.net/v1'});
+    await client.get().then(() => assert('false'), err => {
+      assert(err.statusCode === 404);
+    });
+  });
+
   test('GET public resource', async () => {
     nock('https://fake.taskcluster.net').get('/v1/get-test')
       .reply(200, {})


### PR DESCRIPTION
Per discussion with @eliperelman. This will be useful in tools, where we will use it to set `authorizedScopes` for actions, given an already-configured `Queue` object from the `Clients` component.  I'll make the same change in `taskcluster-client-web` if this is OK.

@eliperelman note that this will mesh well with the adapters we discussed yesterday: the new client will have a reference to the same adapter, so it will share the cached credentials.