### PR TITLE
Tweaks to root url

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,8 @@
 language: node_js
 sudo: false
 node_js:
-- '4'
-- '5'
-- '6'
-- '7'
 - '8'
+- '9'
 addons:
   apt:
     sources:

--- a/README.md
+++ b/README.md
@@ -670,13 +670,13 @@ var auth = new taskcluster.Auth({
 
 This will be the supported way moving forward of pointing taskcluster at
 different instances of taskcluster. This can also be set by setting a
-`TASKCLUSTER_ROOT` env var before importing taskcluster-client. You can also
+`TASKCLUSTER_ROOT_URL` env var before importing taskcluster-client. You can also
 use global config options as below:
 
 ```js
 // Configure default options
 taskcluster.config({
-  rootUrl: "https://somesite.com",
+  rootUrl: "https://somesite.com/api",
 });
 
 // No rootUrl needed here

--- a/README.md
+++ b/README.md
@@ -664,7 +664,7 @@ the `rootUrl` when creating an instance of the client. As illustrated below:
 ```js
 var auth = new taskcluster.Auth({
   credentials:  {...},
-  rootUrl:      "http://whatever.com/api"
+  rootUrl:      "http://whatever.com"
 });
 ```
 
@@ -676,7 +676,7 @@ use global config options as below:
 ```js
 // Configure default options
 taskcluster.config({
-  rootUrl: "https://somesite.com/api",
+  rootUrl: "https://somesite.com",
 });
 
 // No rootUrl needed here
@@ -880,7 +880,7 @@ var dateObject2 = taskcluster.fromNow("1 year", dateObject1);
 Your users may find the options for TaskCluster credentials overwhelming.  You
 can help by interpreting the credentials for them.
 
-The `credentialInformation(credentials, options)` function returns a promise
+The `credentialInformation(rootUrl, credentials)` function returns a promise
 with information about the given credentials:
 
 ```js

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "lodash": "^4.17.4",
     "promise": "^8.0.1",
     "slugid": "^1.1.0",
-    "superagent": "~3.8.1"
+    "superagent": "~3.8.1",
+    "taskcluster-lib-urls": "^1.0.0"
   },
   "files": [
     "lib"
@@ -42,7 +43,7 @@
     "nock": "^9.1.0",
     "pulse-publisher": "^2.0.0",
     "source-map-support": "^0.5.0",
-    "taskcluster-lib-api": "^3.2.3",
+    "taskcluster-lib-api": "^8.3.0",
     "taskcluster-lib-app": "^2.0.3",
     "taskcluster-lib-monitor": "^4.6.3",
     "taskcluster-lib-testing": "^2.0.2",

--- a/src/client.js
+++ b/src/client.js
@@ -14,6 +14,7 @@ var http        = require('http');
 var https       = require('https');
 var Promise     = require('promise');
 var querystring = require('querystring');
+var tcUrl       = require('taskcluster-lib-urls');
 
 /** Default options for our http/https global agents */
 var AGENT_OPTIONS = {
@@ -137,14 +138,13 @@ var makeRequest = function(client, method, url, payload, query) {
  *   // Limit the set of scopes requests with this client may make.
  *   // Note, that your clientId must have a superset of the these scopes.
  *   authorizedScopes:  ['scope1', 'scope2', ...]
- *   baseUrl:         'http://.../v1'                // baseUrl for API requests
  *   exchangePrefix:  'queue/v1/'                    // exchangePrefix prefix
  *   retries:         5,                             // Maximum number of retries
  *   monitor:         await Monitor()                // From taskcluster-lib-monitor
  *   rootUrl:         'https://taskcluster.net/api/' // prefix for all api calls
  * }
  *
- * `baseUrl` and `exchangePrefix` defaults to values from reference.
+ * `exchangePrefix` defaults to values from reference.
  *
  * `rootUrl` and `baseUrl` are mutually exclusive.
  */
@@ -155,22 +155,19 @@ exports.createClient = function(reference, name) {
 
   // Client class constructor
   var Client = function(options) {
-    if (options && options.baseUrl && options.rootUrl) {
-      throw new Error('baseUrl and rootUrl are mutually exclusive. Prefer rootUrl.');
+    if (options && options.baseUrl) {
+      throw new Error('baseUrl has been deprecated!');
     }
     this._options = _.defaults({}, options || {}, {
-      baseUrl:          reference.baseUrl        || '',
       exchangePrefix:   reference.exchangePrefix || '',
+      // We can remove the second half of this assignment once all api definitions are upgraded to have `name`
+      serviceName: reference.name || reference.baseUrl.split('//')[1].split('.')[0],
+      serviceVersion: 'v' + (reference.version + 1),
     }, _defaultOptions);
 
-    // Remove possible trailing slash from baseUrl
-    this._options.baseUrl = this._options.baseUrl.replace(/\/$/, '');
+    assert(this._options.rootUrl, 'Must provide a rootUrl or set the env var TASKCLUSTER_ROOT_URL');
 
-    if (this._options.rootUrl) {
-      // We can remove the second half of this assignment once all api definitions are upgraded to have `name`
-      const urlPrefix = reference.name || reference.baseUrl.split('//')[1].split('.')[0];
-      this._options.baseUrl = `${this._options.rootUrl}/${urlPrefix}/v${reference.version + 1}`;
-    }
+    this._options.rootUrl = this._options.rootUrl.replace(/\/$/, '');
 
     if (this._options.stats) {
       throw new Error('options.stats is now deprecated! Use options.monitor instead.');
@@ -182,7 +179,7 @@ exports.createClient = function(reference, name) {
     }
 
     // Shortcut for which default agent to use...
-    var isHttps = this._options.baseUrl.indexOf('https') === 0;
+    var isHttps = this._options.rootUrl.indexOf('https') === 0;
 
     if (this._options.agent) {
       // We have explicit options for new agent create one...
@@ -288,7 +285,7 @@ exports.createClient = function(reference, name) {
         return text; // Preserve original
       });
       // Create url for the request
-      var url = this._options.baseUrl + endpoint;
+      var url = tcUrl.api(this._options.rootUrl, this._options.serviceName, this._options.serviceVersion, endpoint);
       // Add payload if one is given
       var payload = undefined;
       if (entry.input) {
@@ -565,7 +562,7 @@ exports.createClient = function(reference, name) {
       }
     }
 
-    return this._options.baseUrl + endpoint + query;
+    return tcUrl.api(this._options.rootUrl, this._options.serviceName, this._options.serviceVersion, endpoint) + query;
   };
 
   // Utility function to construct a bewit URL for GET requests
@@ -787,7 +784,7 @@ exports.createTemporaryCredentials = function(options) {
  *    scopes: [...],        // associated scopes (if available)
  * }
  */
-exports.credentialInformation = function(credentials) {
+exports.credentialInformation = function(rootUrl, credentials) {
   var result = {};
   var issuer = credentials.clientId;
 
@@ -818,7 +815,7 @@ exports.credentialInformation = function(credentials) {
     result.type = 'permanent';
   }
 
-  var anonClient = new exports.Auth();
+  var anonClient = new exports.Auth({rootUrl});
   var clientLookup = anonClient.client(issuer).then(function(client) {
     var expires = new Date(client.expires);
     if (!result.expiry || result.expiry > expires) {
@@ -829,7 +826,7 @@ exports.credentialInformation = function(credentials) {
     }
   });
 
-  var credClient = new exports.Auth({credentials: credentials});
+  var credClient = new exports.Auth({rootUrl, credentials});
   var scopeLookup = credClient.currentScopes().then(function(response) {
     result.scopes = response.scopes;
   });

--- a/src/client.js
+++ b/src/client.js
@@ -59,7 +59,7 @@ var _defaultOptions = {
   maxDelay:       30 * 1000,
 
   // The prefix of any api calls. e.g. https://taskcluster.net/api/
-  rootUrl: process.env.TASKCLUSTER_ROOT,
+  rootUrl: process.env.TASKCLUSTER_ROOT_URL,
 
   // Fake methods, if given this will produce a fake client object.
   // Methods called won't make expected HTTP requests, but instead:
@@ -156,7 +156,7 @@ exports.createClient = function(reference, name) {
   // Client class constructor
   var Client = function(options) {
     if (options && options.baseUrl && options.rootUrl) {
-      throw new Error('baseUrl and rootUrl are mutually exlcusive. Prefer rootUrl.');
+      throw new Error('baseUrl and rootUrl are mutually exclusive. Prefer rootUrl.');
     }
     this._options = _.defaults({}, options || {}, {
       baseUrl:          reference.baseUrl        || '',

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -145,13 +145,14 @@ suite('client requests/responses', function() {
 
   const subjects = {
     old: {
-      name: 'baseurl with no rootUrl set',
+      name: 'just https://taskcluster.net',
       urlPrefix: 'https://fake.taskcluster.net',
       Fake: taskcluster.createClient(referenceBaseUrlStyle),
-      rootUrl: null,
+      rootUrl: 'https://taskcluster.net',
       client: (() => {
         const Fake = taskcluster.createClient(referenceBaseUrlStyle);
         return new Fake({
+          rootUrl: 'https://taskcluster.net',
           credentials: {
             clientId: 'nobody',
             accessToken: 'nothing',
@@ -161,7 +162,7 @@ suite('client requests/responses', function() {
     },
     bothWays: {
       name: 'baseurl and rootUrl with rootUrl set',
-      urlPrefix: 'https://whatever.net/fake1',
+      urlPrefix: 'https://whatever.net/api/fake1',
       Fake: taskcluster.createClient(referenceBothStyle),
       rootUrl: 'https://whatever.net',
       client: (() => {
@@ -177,7 +178,7 @@ suite('client requests/responses', function() {
     },
     justRootUrl: {
       name: 'rootUrl set via constructor',
-      urlPrefix: 'https://whatever.net/fake2',
+      urlPrefix: 'https://whatever.net/api/fake2',
       Fake: taskcluster.createClient(referenceNameStyle),
       rootUrl: 'https://whatever.net',
       client: (() => {
@@ -193,13 +194,13 @@ suite('client requests/responses', function() {
     },
     rootUrlWithPath: {
       name: 'rootUrl set via constructor with path',
-      urlPrefix: 'https://whatever.net/api/fake2',
+      urlPrefix: 'https://whatever.net/taskcluster/api/fake2',
       Fake: taskcluster.createClient(referenceNameStyle),
-      rootUrl: 'https://whatever.net/api',
+      rootUrl: 'https://whatever.net/taskcluster',
       client: (() => {
         const Fake = taskcluster.createClient(referenceNameStyle);
         return new Fake({
-          rootUrl: 'https://whatever.net/api',
+          rootUrl: 'https://whatever.net/taskcluster',
           credentials: {
             clientId: 'nobody',
             accessToken: 'nothing',
@@ -209,13 +210,13 @@ suite('client requests/responses', function() {
     },
     rootUrlWithPathAndSubdomain: {
       name: 'rootUrl set via constructor with path and subdomain',
-      urlPrefix: 'https://foo.whatever.net/api/fake2',
+      urlPrefix: 'https://foo.whatever.net/taskcluster/api/fake2',
       Fake: taskcluster.createClient(referenceNameStyle),
-      rootUrl: 'https://foo.whatever.net/api',
+      rootUrl: 'https://foo.whatever.net/taskcluster',
       client: (() => {
         const Fake = taskcluster.createClient(referenceNameStyle);
         return new Fake({
-          rootUrl: 'https://foo.whatever.net/api',
+          rootUrl: 'https://foo.whatever.net/taskcluster',
           credentials: {
             clientId: 'nobody',
             accessToken: 'nothing',
@@ -225,11 +226,11 @@ suite('client requests/responses', function() {
     },
     usingEnvVar: {
       name: 'rootUrl set via env var',
-      urlPrefix: 'https://whatever.net/fake2',
+      urlPrefix: 'https://whatever.net/api/fake2',
       Fake: taskcluster.createClient(referenceNameStyle),
       rootUrl: 'https://whatever.net',
       client: (() => {
-        process.env.TASKCLUSTER_ROOT = 'https://whatever.net';
+        process.env.TASKCLUSTER_ROOT_URL = 'https://whatever.net';
         const clientPath = path.resolve(__dirname, '..', 'lib', 'client.js');
         delete require.cache[clientPath];
         const cleanClient = require(clientPath);
@@ -349,33 +350,6 @@ suite('client requests/responses', function() {
           .reply(200, {});
         await client.paramQuery('test');
       });
-
-      if (subject === 'old') {
-        test('GET with baseUrl', async () => {
-          nock('https://fake-staging.taskcluster.net').get('/v1/get-test')
-            .reply(200, {});
-          let client = new Fake({baseUrl: 'https://fake-staging.taskcluster.net/v1'});
-          await client.get();
-        });
-
-        test('GET with baseUrl (404)', async () => {
-          nock('https://fake-staging.taskcluster.net').get('/v1/get-test')
-            .reply(404, {code: 'NotFoundError'});
-          let client = new Fake({baseUrl: 'https://fake-staging.taskcluster.net/v1'});
-          await client.get().then(() => assert('false'), err => {
-            assert(err.statusCode === 404);
-          });
-        });
-
-        test('Use .use to set baseUrl (404)', async () => {
-          nock('https://fake-staging.taskcluster.net').get('/v1/get-test')
-            .reply(404, {code: 'NotFoundError'});
-          let client = new Fake().use({baseUrl: 'https://fake-staging.taskcluster.net/v1'});
-          await client.get().then(() => assert('false'), err => {
-            assert(err.statusCode === 404);
-          });
-        });
-      }
 
       test('GET public resource', async () => {
         nock(urlPrefix).get('/v1/get-test')

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -240,7 +240,7 @@ suite('client requests/responses', function() {
             accessToken: 'nothing',
           },
         });
-        delete process.env.TASKCLUSTER_ROOT;
+        delete process.env.TASKCLUSTER_ROOT_URL;
         return fake;
       })(),
     },

--- a/test/credinfo_test.js
+++ b/test/credinfo_test.js
@@ -31,7 +31,7 @@ suite('taskcluster.credentialInfo', function() {
   test('permanent', async function() {
     setupNocks({scopes: ['scope1']});
     assert.deepEqual(
-      await taskcluster.credentialInformation({clientId: 'clid'}), {
+      await taskcluster.credentialInformation('https://taskcluster.net', {clientId: 'clid'}), {
         active: true,
         clientId: 'clid',
         type: 'permanent',
@@ -46,7 +46,7 @@ suite('taskcluster.credentialInfo', function() {
       scopes: ['scope1'],
     });
     assert.deepEqual(
-      await taskcluster.credentialInformation({clientId: 'clid'}), {
+      await taskcluster.credentialInformation('https://taskcluster.net', {clientId: 'clid'}), {
         active: false,
         clientId: 'clid',
         type: 'permanent',
@@ -61,7 +61,7 @@ suite('taskcluster.credentialInfo', function() {
       scopes: ['scope1', 'scope2'],
     });
     assert.deepEqual(
-      await taskcluster.credentialInformation({clientId: 'clid'}), {
+      await taskcluster.credentialInformation('https://taskcluster.net', {clientId: 'clid'}), {
         active: false,
         clientId: 'clid',
         type: 'permanent',
@@ -84,7 +84,7 @@ suite('taskcluster.credentialInfo', function() {
 
     setupNocks({scopes: scopes});
     assert.deepEqual(
-      await taskcluster.credentialInformation(credentials), {
+      await taskcluster.credentialInformation('https://taskcluster.net', credentials), {
         active: true,
         clientId: 'clid',
         type: 'temporary',
@@ -109,7 +109,7 @@ suite('taskcluster.credentialInfo', function() {
     var permaExpiry = taskcluster.fromNow('1 day');
     setupNocks({expires: permaExpiry.toJSON(), scopes});
     assert.deepEqual(
-      await taskcluster.credentialInformation(credentials), {
+      await taskcluster.credentialInformation('https://taskcluster.net', credentials), {
         active: true,
         clientId: 'clid',
         type: 'temporary',
@@ -137,7 +137,7 @@ suite('taskcluster.credentialInfo', function() {
     var permaExpiry = taskcluster.fromNow('1 day');
     setupNocks({expires: permaExpiry.toJSON(), scopes});
     assert.deepEqual(
-      await taskcluster.credentialInformation(credentials), {
+      await taskcluster.credentialInformation('https://taskcluster.net', credentials), {
         active: true,
         clientId: 'clid',
         type: 'temporary',

--- a/test/creds_test.js
+++ b/test/creds_test.js
@@ -12,6 +12,7 @@ suite('client credential handling', function() {
   let client = function(options) {
     options = _.defaults({}, options || {}, {
       credentials: {},
+      rootUrl: 'https://taskcluster.net',
     });
     options.credentials = _.defaults({}, options.credentials, {
       clientId: 'tester',
@@ -372,7 +373,7 @@ suite('client credential handling', function() {
     });
 
     test('implicit credentials', async () => {
-      let client = new cleanClient.Auth();
+      let client = new cleanClient.Auth({rootUrl: 'https://taskcluster.net'});
       assert.deepEqual(
         await client.testAuthenticate({
           clientScopes: [],

--- a/test/retry_test.js
+++ b/test/retry_test.js
@@ -15,6 +15,7 @@ suite('retry-test', function() {
   var api = new API({
     title:        'Retry API',
     description:  'API that sometimes works by retrying things',
+    name:         'retrytest',
   });
 
   var getInternalErrorCount = 0;
@@ -23,8 +24,7 @@ suite('retry-test', function() {
     route:        '/internal-error',
     name:         'getInternalError',
     title:        'Test End-Point',
-    scopes:       [['test:internal-error']],
-    deferAuth:    false,
+    scopes:       'test:internal-error',
     description:  'Place we can call to test something',
   }, function(req, res) {
     getInternalErrorCount += 1;
@@ -41,8 +41,7 @@ suite('retry-test', function() {
     route:        '/internal-error-sometimes',
     name:         'getOccasionalInternalError',
     title:        'Test End-Point',
-    scopes:       [['test:internal-error']],
-    deferAuth:    false,
+    scopes:       'test:internal-error',
     description:  'Place we can call to test something',
   }, function(req, res) {
     getOccasionalInternalErrorCount += 1;
@@ -67,8 +66,7 @@ suite('retry-test', function() {
     route:        '/user-error',
     name:         'getUserError',
     title:        'Test End-Point',
-    scopes:       [['test:internal-error']],
-    deferAuth:    false,
+    scopes:       'test:internal-error',
     description:  'Place we can call to test something',
   }, function(req, res) {
     getUserErrorCount += 1;
@@ -85,8 +83,7 @@ suite('retry-test', function() {
     route:        '/connection-error',
     name:         'getConnectionError',
     title:        'Test End-Point',
-    scopes:       [['test:internal-error']],
-    deferAuth:    false,
+    scopes:       'test:internal-error',
     description:  'Place we can call to test something',
   }, function(req, res) {
     getConnectionErrorCount += 1;
@@ -131,7 +128,7 @@ suite('retry-test', function() {
           clientId:     'test-client',
           accessToken:  'test-token',
         },
-        baseUrl:        'http://localhost:60526/v1',
+        rootUrl:        'http://localhost:60526',
         monitor,
       });
 
@@ -144,7 +141,7 @@ suite('retry-test', function() {
       });
 
       // Use router
-      app.use('/v1', router);
+      app.use('/api/retrytest/v1', router);
 
       return app.createServer().then(function(server) {
         _apiServer = server;
@@ -198,7 +195,7 @@ suite('retry-test', function() {
         clientId:     'test-client',
         accessToken:  'test-token',
       },
-      baseUrl:        'http://localhost:60526/v1',
+      rootUrl:        'http://localhost:60526',
       monitor:        m,
     });
     return server2.getOccasionalInternalError().then(function() {
@@ -213,7 +210,7 @@ suite('retry-test', function() {
         clientId:     'test-client',
         accessToken:  'test-token',
       },
-      baseUrl:        'http://localhost:60526/v1',
+      rootUrl:        'http://localhost:60526',
       retries:        0,
     });
     getInternalErrorCount = 0;
@@ -231,7 +228,7 @@ suite('retry-test', function() {
         clientId:     'test-client',
         accessToken:  'test-token',
       },
-      baseUrl:        'http://localhost:60526/v1',
+      rootUrl:        'http://localhost:60526',
       retries:        1,
     });
     getInternalErrorCount = 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,13 +2,6 @@
 # yarn lockfile v1
 
 
-accepts@~1.1.0:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.1.4.tgz#d71c96f7d41d0feda2c38cd14e8a27c04158df4a"
-  dependencies:
-    mime-types "~2.0.4"
-    negotiator "0.4.9"
-
 accepts@~1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.4.tgz#86246758c7dd6d21a6474ff084a4740ec05eb21f"
@@ -160,6 +153,21 @@ aws-sdk@^2.142.0, aws-sdk@^2.144.0:
     buffer "4.9.1"
     crypto-browserify "1.0.9"
     events "^1.1.1"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.1.0"
+    xml2js "0.4.17"
+    xmlbuilder "4.2.1"
+
+aws-sdk@^2.151.0:
+  version "2.233.1"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.233.1.tgz#b4f541069a9f2781e9f73e1336ce81a9fc08bcf1"
+  dependencies:
+    buffer "4.9.1"
+    events "1.1.1"
+    ieee754 "1.1.8"
     jmespath "0.15.0"
     querystring "0.2.0"
     sax "1.2.1"
@@ -618,13 +626,7 @@ babel-register@^6.26.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
-babel-runtime@^5.8.25:
-  version "5.8.38"
-  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-5.8.38.tgz#1c0b02eb63312f5f087ff20450827b425c9d4c19"
-  dependencies:
-    core-js "^1.0.0"
-
-babel-runtime@^6.0.0, babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.20.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0, babel-runtime@^6.9.2:
+babel-runtime@^6.0.0, babel-runtime@^6.18.0, babel-runtime@^6.20.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0, babel-runtime@^6.9.2:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
@@ -718,21 +720,6 @@ bluebird@^3.5.0:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
 
-body-parser@1.13.3:
-  version "1.13.3"
-  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.13.3.tgz#c08cf330c3358e151016a05746f13f029c97fa97"
-  dependencies:
-    bytes "2.1.0"
-    content-type "~1.0.1"
-    debug "~2.2.0"
-    depd "~1.0.1"
-    http-errors "~1.3.1"
-    iconv-lite "0.4.11"
-    on-finished "~2.3.0"
-    qs "4.0.0"
-    raw-body "~2.1.2"
-    type-is "~1.6.6"
-
 body-parser@1.18.2:
   version "1.18.2"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.18.2.tgz#87678a19d84b47d859b83199bd59bce222b10454"
@@ -790,10 +777,6 @@ browser-stdout@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
 
-buffer-crc32@0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.3.tgz#bb54519e95d107cbd2400e76d0cab1467336d921"
-
 buffer-equal-constant-time@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
@@ -813,14 +796,6 @@ buffer@4.9.1:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
     isarray "^1.0.0"
-
-bytes@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/bytes/-/bytes-2.1.0.tgz#ac93c410e2ffc9cc7cf4b464b38289067f5e47b4"
-
-bytes@2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/bytes/-/bytes-2.4.0.tgz#7d97196f9d5baf7f6935e25985549edd2a6c2339"
 
 bytes@3.0.0:
   version "3.0.0"
@@ -930,10 +905,6 @@ commander@2.11.0, commander@^2.11.0, commander@^2.8.1:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
 
-component-emitter@1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.1.2.tgz#296594f2753daa63996d2af08d15a95116c9aec3"
-
 component-emitter@^1.2.0, component-emitter@~1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
@@ -958,10 +929,6 @@ content-security-policy@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/content-security-policy/-/content-security-policy-0.3.0.tgz#7610a7c2175bb3339cc088b2961dbb40135a9aa4"
 
-content-type@~1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.2.tgz#b7d113aee7a8dd27bd21133c4dc2529df1721eed"
-
 content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
@@ -970,25 +937,13 @@ convert-source-map@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.0.tgz#9acd70851c6d5dfdd93d9282e5edf94a03ff46b5"
 
-cookie-signature@1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.5.tgz#a122e3f1503eca0f5355795b0711bb2368d450f9"
-
 cookie-signature@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
 
-cookie@0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.1.2.tgz#72fec3d24e48a3432073d90c12642005061004b1"
-
 cookie@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
-
-cookiejar@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.0.1.tgz#3d12752f6adf68a892f332433492bd5812bb668f"
 
 cookiejar@2.0.6:
   version "2.0.6"
@@ -997,10 +952,6 @@ cookiejar@2.0.6:
 cookiejar@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.1.tgz#41ad57b1b555951ec171412a81942b1e8200d34a"
-
-core-js@^1.0.0:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
 core-js@^2.4.0:
   version "2.4.1"
@@ -1013,10 +964,6 @@ core-js@^2.5.0:
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
-
-crc@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/crc/-/crc-3.0.0.tgz#d11e97ec44a844e5eb15a74fa2c7875d0aac4b22"
 
 create-error-class@^3.0.1:
   version "3.0.2"
@@ -1038,7 +985,7 @@ cryptiles@0.2.x:
   dependencies:
     boom "0.4.x"
 
-cryptiles@2.x.x, cryptiles@^2.0.4:
+cryptiles@2.x.x:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
   dependencies:
@@ -1082,24 +1029,6 @@ debug@3.1.0, debug@^3.0.1, debug@^3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@~1.0.1:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-1.0.4.tgz#5b9c256bd54b6ec02283176fa8a0ede6d154cbf8"
-  dependencies:
-    ms "0.6.2"
-
-debug@~2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.0.0.tgz#89bd9df6732b51256bc6705342bba02ed12131ef"
-  dependencies:
-    ms "0.6.2"
-
-debug@~2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
-  dependencies:
-    ms "0.7.1"
-
 deep-eql@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-0.1.3.tgz#ef558acab8de25206cd713906d74e56930eb69f2"
@@ -1134,25 +1063,9 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
 
-depd@0.4.4:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/depd/-/depd-0.4.4.tgz#07091fae75f97828d89b4a02a2d4778f0e7c0662"
-
-depd@0.4.5:
-  version "0.4.5"
-  resolved "https://registry.yarnpkg.com/depd/-/depd-0.4.5.tgz#1a664b53388b4a6573e8ae67b5f767c693ca97f1"
-
 depd@1.1.1, depd@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.1.tgz#5783b4e1c459f06fa5ca27f991f3d06e7a310359"
-
-depd@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/depd/-/depd-1.0.1.tgz#80aec64c9d6d97e65cc2a9caa93c0aa6abf73aaa"
-
-destroy@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.3.tgz#b433b4724e71fd8551d9885174851c5fc377e2c9"
 
 destroy@~1.0.4:
   version "1.0.4"
@@ -1194,14 +1107,6 @@ ecdsa-sig-formatter@1.0.9:
     base64url "^2.0.0"
     safe-buffer "^5.0.1"
 
-ee-first@1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.0.5.tgz#8c9b212898d8cd9f1a9436650ce7be202c9e9ff0"
-
-ee-first@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.0.tgz#6a0d7c6221e490feefd92ec3f441c9ce8cd097f4"
-
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
@@ -1215,10 +1120,6 @@ error-ex@^1.2.0:
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
   dependencies:
     is-arrayish "^0.2.1"
-
-escape-html@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.1.tgz#181a286ead397a39a92857cfb1d43052e356bff0"
 
 escape-html@~1.0.3:
   version "1.0.3"
@@ -1315,23 +1216,11 @@ esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
-etag@~1.3.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/etag/-/etag-1.3.1.tgz#e51925728688a32dc4eea1cfa9ab4f734d055567"
-  dependencies:
-    crc "3.0.0"
-
-etag@~1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/etag/-/etag-1.4.0.tgz#3050991615857707c04119d075ba2088e0701225"
-  dependencies:
-    crc "3.0.0"
-
 etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
 
-events@^1.1.1:
+events@1.1.1, events@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
 
@@ -1380,35 +1269,6 @@ express@4.16.2:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
-express@4.9.0:
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/express/-/express-4.9.0.tgz#9b2ea4ebce57c7ac710604c74f6c303ab344a7f3"
-  dependencies:
-    accepts "~1.1.0"
-    buffer-crc32 "0.2.3"
-    cookie "0.1.2"
-    cookie-signature "1.0.5"
-    debug "~2.0.0"
-    depd "0.4.4"
-    escape-html "1.0.1"
-    etag "~1.3.0"
-    finalhandler "0.2.0"
-    fresh "0.2.4"
-    media-typer "0.3.0"
-    merge-descriptors "0.0.2"
-    methods "1.1.0"
-    on-finished "~2.1.0"
-    parseurl "~1.3.0"
-    path-to-regexp "0.1.3"
-    proxy-addr "1.0.1"
-    qs "2.2.3"
-    range-parser "~1.0.2"
-    send "0.9.1"
-    serve-static "~1.6.1"
-    type-is "~1.5.1"
-    utils-merge "1.0.0"
-    vary "~1.0.0"
-
 extend@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.0.tgz#5a474353b9f3353ddd8176dfd37b91c83a46f1d4"
@@ -1416,10 +1276,6 @@ extend@3.0.0:
 extend@^3.0.0, extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
-
-extend@~1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/extend/-/extend-1.2.1.tgz#a0f5fd6cfc83a5fe49ef698d60ec8a624dd4576c"
 
 external-editor@^2.0.4:
   version "2.0.5"
@@ -1468,13 +1324,6 @@ file-entry-cache@^2.0.0:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
 
-finalhandler@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-0.2.0.tgz#794082424b17f6a4b2a0eda39f9db6948ee4be8d"
-  dependencies:
-    debug "~2.0.0"
-    escape-html "1.0.1"
-
 finalhandler@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.0.tgz#ce0b6855b45853e791b2fcc680046d88253dd7f5"
@@ -1504,14 +1353,6 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
 
-form-data@0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-0.1.3.tgz#4ee4346e6eb5362e8344a02075bd8dbd8c7373ea"
-  dependencies:
-    async "~0.9.0"
-    combined-stream "~0.0.4"
-    mime "~1.2.11"
-
 form-data@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-0.2.0.tgz#26f8bc26da6440e299cbdcfb69035c4f77a6e466"
@@ -1528,10 +1369,6 @@ form-data@^2.3.1, form-data@~2.3.1:
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
-formidable@1.0.14:
-  version "1.0.14"
-  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.0.14.tgz#2b3f4c411cbb5fdd695c44843e2a23514a43231a"
-
 formidable@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.1.1.tgz#96b8886f7c3c3508b932d6bd70c4d3a88f35f1a9"
@@ -1543,10 +1380,6 @@ formidable@~1.0.14:
 forwarded@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
-
-fresh@0.2.4:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.2.4.tgz#3582499206c9723714190edd74b4604feb4a614c"
 
 fresh@0.5.2:
   version "0.5.2"
@@ -1674,6 +1507,15 @@ hawk@2.3.0:
     hoek "2.x.x"
     sntp "1.x.x"
 
+hawk@6.0.2, hawk@^6.0.2, hawk@~6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/hawk/-/hawk-6.0.2.tgz#af4d914eb065f9b5ce4d9d11c1cb2126eecc3038"
+  dependencies:
+    boom "4.x.x"
+    cryptiles "3.x.x"
+    hoek "4.x.x"
+    sntp "2.x.x"
+
 hawk@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/hawk/-/hawk-2.3.1.tgz#1e731ce39447fa1d0f6d707f7bceebec0fd1ec1f"
@@ -1682,15 +1524,6 @@ hawk@^2.3.1:
     cryptiles "2.x.x"
     hoek "2.x.x"
     sntp "1.x.x"
-
-hawk@^6.0.2, hawk@~6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/hawk/-/hawk-6.0.2.tgz#af4d914eb065f9b5ce4d9d11c1cb2126eecc3038"
-  dependencies:
-    boom "4.x.x"
-    cryptiles "3.x.x"
-    hoek "4.x.x"
-    sntp "2.x.x"
 
 hawk@~1.0.0:
   version "1.0.0"
@@ -1737,13 +1570,6 @@ http-errors@1.6.2, http-errors@~1.6.2:
     setprototypeof "1.0.3"
     statuses ">= 1.3.1 < 2"
 
-http-errors@~1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.3.1.tgz#197e22cdebd4198585e8694ef6786197b91ed942"
-  dependencies:
-    inherits "~2.0.1"
-    statuses "1"
-
 http-signature@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
@@ -1752,19 +1578,11 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-iconv-lite@0.4.11:
-  version "0.4.11"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.11.tgz#2ecb42fd294744922209a2e7c404dac8793d8ade"
-
-iconv-lite@0.4.13:
-  version "0.4.13"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
-
 iconv-lite@0.4.19, iconv-lite@^0.4.17:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
-ieee754@^1.1.4:
+ieee754@1.1.8, ieee754@^1.1.4:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
 
@@ -1811,10 +1629,6 @@ invariant@^2.2.2:
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
   dependencies:
     loose-envify "^1.0.0"
-
-ipaddr.js@0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-0.1.2.tgz#6a1fd3d854f5002965c34d7bbcd9b4a8d4b0467e"
 
 ipaddr.js@1.5.2:
   version "1.5.2"
@@ -2031,21 +1845,9 @@ media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
 
-merge-descriptors@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-0.0.2.tgz#c36a52a781437513c57275f39dd9d317514ac8c7"
-
 merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
-
-methods@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/methods/-/methods-1.0.1.tgz#75bc91943dffd7da037cf3eeb0ed73a0037cd14b"
-
-methods@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.0.tgz#5dca4ee12df52ff3b056145986a8f01cbc86436f"
 
 methods@^1.1.1, methods@~1.1.1, methods@~1.1.2:
   version "1.1.2"
@@ -2055,13 +1857,13 @@ mime-db@~1.12.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.12.0.tgz#3d0c63180f458eb10d325aaa37d7c58ae312e9d7"
 
-mime-db@~1.26.0:
-  version "1.26.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.26.0.tgz#eaffcd0e4fc6935cf8134da246e2e6c35305adff"
-
 mime-db@~1.30.0:
   version "1.30.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.30.0.tgz#74c643da2dd9d6a45399963465b26d5ca7d71f01"
+
+mime-db@~1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.33.0.tgz#a3492050a5cb9b63450541e39d9788d2272783db"
 
 mime-types@^2.1.12, mime-types@~2.1.15, mime-types@~2.1.16, mime-types@~2.1.17:
   version "2.1.17"
@@ -2069,21 +1871,17 @@ mime-types@^2.1.12, mime-types@~2.1.15, mime-types@~2.1.16, mime-types@~2.1.17:
   dependencies:
     mime-db "~1.30.0"
 
-mime-types@~2.0.3, mime-types@~2.0.4, mime-types@~2.0.9:
+mime-types@~2.0.3:
   version "2.0.14"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.0.14.tgz#310e159db23e077f8bb22b748dabfa4957140aa6"
   dependencies:
     mime-db "~1.12.0"
 
-mime-types@~2.1.13:
-  version "2.1.14"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.14.tgz#f7ef7d97583fcaf3b7d282b6f8b5679dab1e94ee"
+mime-types@~2.1.18:
+  version "2.1.18"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.18.tgz#6f323f60a83d11146f831ff11fd66e2fe5503bb8"
   dependencies:
-    mime-db "~1.26.0"
-
-mime@1.2.11, mime@~1.2.11:
-  version "1.2.11"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-1.2.11.tgz#58203eed86e3a5ef17aed2b7d9ebd47f0a60dd10"
+    mime-db "~1.33.0"
 
 mime@1.3.4:
   version "1.3.4"
@@ -2150,14 +1948,6 @@ morgan@^1.9.0:
     on-finished "~2.3.0"
     on-headers "~1.0.1"
 
-ms@0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-0.6.2.tgz#d89c2124c6fdc1353d65a8b77bf1aac4b193708c"
-
-ms@0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
-
 ms@0.7.2:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
@@ -2181,10 +1971,6 @@ nan@^2.0.9:
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
-
-negotiator@0.4.9:
-  version "0.4.9"
-  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.4.9.tgz#92e46b6db53c7e421ed64a2bc94f08be7630df3f"
 
 negotiator@0.6.1:
   version "0.6.1"
@@ -2223,18 +2009,6 @@ oauth-sign@~0.8.2:
 object-assign@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
-
-on-finished@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.1.0.tgz#0c539f09291e8ffadde0c8a25850fb2cedc7022d"
-  dependencies:
-    ee-first "1.0.5"
-
-on-finished@~2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.1.1.tgz#f82ca1c9e3a4f3286b1b9938610e5b8636bd3cb2"
-  dependencies:
-    ee-first "1.1.0"
 
 on-finished@~2.3.0:
   version "2.3.0"
@@ -2289,10 +2063,6 @@ parse-json@^2.1.0:
   dependencies:
     error-ex "^1.2.0"
 
-parseurl@~1.3.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.1.tgz#c8ab8c9223ba34888aa64a297b28853bec18da56"
-
 parseurl@~1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.2.tgz#fc289d4ed8993119460c156253262cdc8de65bf3"
@@ -2304,10 +2074,6 @@ path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
 path-is-inside@^1.0.1, path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
-
-path-to-regexp@0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.3.tgz#21b9ab82274279de25b156ea08fd12ca51b8aecb"
 
 path-to-regexp@0.1.7:
   version "0.1.7"
@@ -2387,12 +2153,6 @@ propagate@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/propagate/-/propagate-0.4.0.tgz#f3fcca0a6fe06736a7ba572966069617c130b481"
 
-proxy-addr@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-1.0.1.tgz#c7c566d5eb4e3fad67eeb9c77c5558ccc39b88a8"
-  dependencies:
-    ipaddr.js "0.1.2"
-
 proxy-addr@~2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.2.tgz#6571504f47bb988ec8180253f85dd7e14952bdec"
@@ -2426,25 +2186,17 @@ punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
-qs@0.6.6, qs@^0.6.6:
-  version "0.6.6"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-0.6.6.tgz#6e015098ff51968b8a3c819001d5f2c89bc4b107"
-
-qs@2.2.3:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-2.2.3.tgz#6139c1f47960eff5655e56aab0ef9f6dd16d4eeb"
-
 qs@2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/qs/-/qs-2.3.3.tgz#e9e85adbe75da0bbe4c8e0476a086290f863b404"
 
-qs@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-4.0.0.tgz#c31d9b74ec27df75e543a86c78728ed8d4623607"
-
 qs@6.5.1, qs@^6.5.1, qs@~6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
+
+qs@^0.6.6:
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-0.6.6.tgz#6e015098ff51968b8a3c819001d5f2c89bc4b107"
 
 qs@^6.0.2:
   version "6.4.0"
@@ -2457,10 +2209,6 @@ querystring@0.2.0:
 querystringify@0.0.x:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-0.0.4.tgz#0cf7f84f9463ff0ae51c4c4b142d95be37724d9c"
-
-range-parser@~1.0.0, range-parser@~1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.0.3.tgz#6872823535c692e2c2a0103826afd82c2e0ff175"
 
 range-parser@~1.2.0:
   version "1.2.0"
@@ -2483,14 +2231,6 @@ raw-body@2.3.2:
     bytes "3.0.0"
     http-errors "1.6.2"
     iconv-lite "0.4.19"
-    unpipe "1.0.0"
-
-raw-body@~2.1.2:
-  version "2.1.7"
-  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.1.7.tgz#adfeace2e4fb3098058014d08c072dcc59758774"
-  dependencies:
-    bytes "2.4.0"
-    iconv-lite "0.4.13"
     unpipe "1.0.0"
 
 read-all-stream@^3.0.0:
@@ -2691,36 +2431,6 @@ send@0.16.1:
     range-parser "~1.2.0"
     statuses "~1.3.1"
 
-send@0.9.1:
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/send/-/send-0.9.1.tgz#d93689f7c9ce36bd32f8ee572bb60bda032edc23"
-  dependencies:
-    debug "~2.0.0"
-    depd "0.4.4"
-    destroy "1.0.3"
-    escape-html "1.0.1"
-    etag "~1.3.0"
-    fresh "0.2.4"
-    mime "1.2.11"
-    ms "0.6.2"
-    on-finished "2.1.0"
-    range-parser "~1.0.0"
-
-send@0.9.3:
-  version "0.9.3"
-  resolved "https://registry.yarnpkg.com/send/-/send-0.9.3.tgz#b43a7414cd089b7fbec9b755246f7c37b7b85cc0"
-  dependencies:
-    debug "~2.0.0"
-    depd "0.4.5"
-    destroy "1.0.3"
-    escape-html "1.0.1"
-    etag "~1.4.0"
-    fresh "0.2.4"
-    mime "1.2.11"
-    ms "0.6.2"
-    on-finished "2.1.0"
-    range-parser "~1.0.2"
-
 serve-static@1.13.1:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.13.1.tgz#4c57d53404a761d8f2e7c1e8a18a47dbf278a719"
@@ -2729,15 +2439,6 @@ serve-static@1.13.1:
     escape-html "~1.0.3"
     parseurl "~1.3.2"
     send "0.16.1"
-
-serve-static@~1.6.1:
-  version "1.6.5"
-  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.6.5.tgz#aca17e0deac4a87729f6078781b7d27f63aa3d9c"
-  dependencies:
-    escape-html "1.0.1"
-    parseurl "~1.3.0"
-    send "0.9.3"
-    utils-merge "1.0.0"
 
 setprototypeof@1.0.3:
   version "1.0.3"
@@ -2862,13 +2563,13 @@ statsum@^0.5.1:
     url-join "^0.0.1"
     uuid "^2.0.2"
 
-statuses@1, statuses@~1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.3.1.tgz#faf51b9eb74aaef3b3acf4ad5f61abf24cb7b93e"
-
 "statuses@>= 1.3.1 < 2":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"
+
+statuses@~1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.3.1.tgz#faf51b9eb74aaef3b3acf4ad5f61abf24cb7b93e"
 
 string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
@@ -2907,12 +2608,6 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
-superagent-hawk@0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/superagent-hawk/-/superagent-hawk-0.0.4.tgz#43323cc1f3d778b5dabc3d1363fa5f1a861a14ee"
-  dependencies:
-    hawk "~1.0.0"
-
 superagent-hawk@0.0.6, superagent-hawk@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/superagent-hawk/-/superagent-hawk-0.0.6.tgz#0cfb70e21546e3a3e902da208a28edd965f82dab"
@@ -2920,29 +2615,9 @@ superagent-hawk@0.0.6, superagent-hawk@^0.0.6:
     hawk "~1.0.0"
     qs "^0.6.6"
 
-superagent-promise@0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/superagent-promise/-/superagent-promise-0.1.2.tgz#a1abff51422c53732b6c1ed7d995debc39b88f57"
-
 superagent-promise@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/superagent-promise/-/superagent-promise-0.2.0.tgz#91c77f4cb0c9cf41beeb917d8add697f6d15caea"
-
-superagent@0.18.2:
-  version "0.18.2"
-  resolved "https://registry.yarnpkg.com/superagent/-/superagent-0.18.2.tgz#9afc6276a9475f4bdcd535ac6a0685ebc4b560eb"
-  dependencies:
-    component-emitter "1.1.2"
-    cookiejar "2.0.1"
-    debug "~1.0.1"
-    extend "~1.2.1"
-    form-data "0.1.3"
-    formidable "1.0.14"
-    methods "1.0.1"
-    mime "1.2.11"
-    qs "0.6.6"
-    readable-stream "1.0.27-1"
-    reduce-component "1.0.1"
 
 superagent@3.8.0:
   version "3.8.0"
@@ -3045,7 +2720,7 @@ taskcluster-client@3.0.3:
     slugid "^1.1.0"
     superagent "~3.7.0"
 
-taskcluster-client@^1.0.1, taskcluster-client@^1.2.0:
+taskcluster-client@^1.0.1:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/taskcluster-client/-/taskcluster-client-1.6.3.tgz#46e08445b7fcb590d4effb35df3f21bab0bb6da2"
   dependencies:
@@ -3079,28 +2754,37 @@ taskcluster-client@^2.4.3:
   optionalDependencies:
     sockjs-client "^1.0.3"
 
-taskcluster-lib-api@^3.2.3:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/taskcluster-lib-api/-/taskcluster-lib-api-3.2.3.tgz#9c807e4c97537b14961ec2232f99d6fcd00717c0"
+taskcluster-client@^3.1.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/taskcluster-client/-/taskcluster-client-3.4.0.tgz#3b0e933d6aaf8354c8e44a8db29d5b2e12e41f64"
   dependencies:
-    ajv "^4.8.2"
-    aws-sdk "^2.5.3"
-    babel-runtime "^6.11.6"
-    body-parser "1.13.3"
-    cryptiles "^2.0.4"
-    debug "^2.2.0"
-    express "4.9.0"
-    hawk "2.3.0"
-    lodash "^4.15.0"
-    promise "^7.1.1"
+    amqplib "^0.5.1"
+    babel-runtime "^6.26.0"
+    debug "^3.1.0"
+    hawk "^6.0.2"
+    lodash "^4.17.4"
+    promise "^8.0.1"
     slugid "^1.1.0"
-    superagent "0.18.2"
-    superagent-hawk "0.0.4"
-    superagent-promise "0.1.2"
-    taskcluster-client "^1.2.0"
-    taskcluster-lib-scopes "^0.8.8"
-    type-is "^1.6.10"
-    uuid "^2.0.1"
+    superagent "~3.8.1"
+
+taskcluster-lib-api@^8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/taskcluster-lib-api/-/taskcluster-lib-api-8.3.0.tgz#ced009510f74d1494e81e7a159c9de5814d80742"
+  dependencies:
+    ajv "^5.3.0"
+    aws-sdk "^2.151.0"
+    babel-runtime "^6.26.0"
+    body-parser "1.18.2"
+    debug "^3.1.0"
+    express "4.16.2"
+    hawk "6.0.2"
+    lodash "^4.15.0"
+    promise "^8.0.1"
+    slugid "^1.1.0"
+    taskcluster-client "^3.1.0"
+    taskcluster-lib-scopes "^1.9.0"
+    type-is "^1.6.15"
+    uuid "^3.1.0"
 
 taskcluster-lib-app@^2.0.3:
   version "2.0.3"
@@ -3132,11 +2816,11 @@ taskcluster-lib-monitor@^4.6.3:
     taskcluster-client "^1.0.1"
     usage "^0.7.1"
 
-taskcluster-lib-scopes@^0.8.8:
-  version "0.8.8"
-  resolved "https://registry.yarnpkg.com/taskcluster-lib-scopes/-/taskcluster-lib-scopes-0.8.8.tgz#6c67f1b719b6aaa00138de499083fc7e12009bdd"
+taskcluster-lib-scopes@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/taskcluster-lib-scopes/-/taskcluster-lib-scopes-1.9.0.tgz#c8d6113d386d432b96eb73cfb182a335c5f49a90"
   dependencies:
-    babel-runtime "^5.8.25"
+    babel-runtime "^6.26.0"
 
 taskcluster-lib-testing@^2.0.2:
   version "2.0.2"
@@ -3158,6 +2842,10 @@ taskcluster-lib-testing@^2.0.2:
     taskcluster-client "3.0.3"
     taskcluster-lib-validate "^3.0.1"
     uuid "^3.1.0"
+
+taskcluster-lib-urls@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/taskcluster-lib-urls/-/taskcluster-lib-urls-1.0.0.tgz#ebe6224384903d71b113bf26d63ff7cac48440b9"
 
 taskcluster-lib-validate@^3.0.1:
   version "3.0.1"
@@ -3242,26 +2930,19 @@ type-detect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-1.0.0.tgz#762217cc06db258ec48908a1298e8b95121e8ea2"
 
-type-is@^1.6.10, type-is@~1.6.15:
+type-is@^1.6.15:
+  version "1.6.16"
+  resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.16.tgz#f89ce341541c672b25ee7ae3c73dee3b2be50194"
+  dependencies:
+    media-typer "0.3.0"
+    mime-types "~2.1.18"
+
+type-is@~1.6.15:
   version "1.6.15"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.15.tgz#cab10fb4909e441c82842eafe1ad646c81804410"
   dependencies:
     media-typer "0.3.0"
     mime-types "~2.1.15"
-
-type-is@~1.5.1:
-  version "1.5.7"
-  resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.5.7.tgz#b9368a593cc6ef7d0645e78b2f4c64cbecd05e90"
-  dependencies:
-    media-typer "0.3.0"
-    mime-types "~2.0.9"
-
-type-is@~1.6.6:
-  version "1.6.14"
-  resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.14.tgz#e219639c17ded1ca0789092dd54a03826b817cb2"
-  dependencies:
-    media-typer "0.3.0"
-    mime-types "~2.1.13"
 
 typedarray@^0.0.6:
   version "0.0.6"
@@ -3321,10 +3002,6 @@ util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
-utils-merge@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.0.tgz#0294fb922bb9375153541c4f7096231f287c8af8"
-
 utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
@@ -3340,10 +3017,6 @@ uuid@3.1.0, uuid@^3.1.0:
 uuid@^2.0.1, uuid@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
-
-vary@~1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/vary/-/vary-1.0.1.tgz#99e4981566a286118dfb2b817357df7993376d10"
 
 vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
This does two things. First one we've agreed upon. Second I'm happy to remove if we don't want it.

1. Change `TASKCLUSTER_ROOT` to `TASKCLUSTER_ROOT_URL`
2. Uses taskcluster-lib-urls to build urls