### PR TITLE
Correctly interpret serviceName for baseUrls without protocols

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -166,7 +166,8 @@ exports.createClient = function(reference, name) {
         // it was called this for a while; https://bugzilla.mozilla.org/show_bug.cgi?id=1463207
         serviceName = reference.name;
       } else if (reference.baseUrl) {
-        serviceName = reference.baseUrl.split('//')[1].split('.')[0];
+        let parts = reference.baseUrl.split('//');
+        serviceName = (parts[1] || parts[0]).split('.')[0];
       } else if (reference.exchangePrefix) {
         serviceName = reference.exchangePrefix.split('/')[1].replace('taskcluster-', '');
       }


### PR DESCRIPTION
For example, ec2-manager has a `baseUrl` of `localhost:5555/v1`.
